### PR TITLE
fix(release): Use the correct branch name for semantic-release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,6 @@
 {
     branches: [
-                {name: 'mainline'},
+                {name: 'main'},
                 {name: 'next', channel: 'next'}
             ],
     "plugins": [


### PR DESCRIPTION
Our main branch is `main` - this updates `.releaserc` to match!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
