### PR TITLE
fix: Commit the change log back to main

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,7 +7,7 @@
         "@semantic-release/commit-analyzer",
         "@semantic-release/release-notes-generator",
         ["@semantic-release/changelog", {
-            "changelogFile": "RELEASENOTES.md",
+            "changelogFile": "CHANGELOG.md",
         }],
         ["@semantic-release/npm", {
             "pkgRoot": "./build",
@@ -15,5 +15,8 @@
         ["@semantic-release/exec", {
             "successCmd": "echo ${nextRelease.version} > RELEASED"
         }],
+        ["@semantic-release/git", {
+            "assets": ["CHANGELOG.md"],
+        }]
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+[//]: <> (The release notes will be generated in the pipeline during build time. This is a placeholder.)


### PR DESCRIPTION
This PR is to update the release process to generate the CHANGELOG.md and commit it back to the main.
Once it works, we will update the release notes in the README file and also update the CHANGELOG.md to include the initial message. 