### PR TITLE
build: Install the git secrets so that the Travis build can pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
 language: node_js
-install: skip
-script: ./scripts/build.sh
+os: linux
+dist: focal
+install: 
+  - pushd /tmp && git clone --depth 1 https://github.com/awslabs/git-secrets.git && cd ./git-secrets && PREFIX=/tmp/git-secrets make install && popd
+  - npm install -g typescript
+script: 
+  - export PATH=/tmp/git-secrets/bin:$PATH
+  - ./scripts/build.sh

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "aws-northstar"
   ],
   "scripts": {
-    "build:build-readme": "cat ./docs/GettingStarted.md >> ./build/README.md",
-    "build:copy-file": "cp ./{package.json,LICENSE,NOTICE,LICENSE-THIRD-PARTY} ./build/ && cp ./README_NPM_PACKAGE.md ./build/README.md",
+    "build:build-readme": "cp ./README_NPM_PACKAGE.md ./build/README.md && cat ./docs/GettingStarted.md >> ./build/README.md",
+    "build:copy-file": "cp ./package.json ./build/",
     "build": "tsc --build tsconfig.build.json && npm run generate:attribution && npm run build:copy-file && npm run build:build-readme",
     "check:all": "npm run test:all && npm run build && npm run storybook:build && npm run styleguide:build",
     "generate:attribution": "generate-attribution && mv oss-attribution/attribution.txt LICENSE-THIRD-PARTY",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,6 +14,11 @@ echo 'Remove build folder to make sure the npm package only includes clean built
 if [ -d "./build" ]; then rm -rf ./build; fi # 
 npm run build
 
+echo 'Copy license files'
+cp ./LICENSE ./build/
+cp ./NOTICE ./build/
+cp ./LICENSE-THIRD-PARTY ./build/
+
 echo 'Copy the examples to published examples folder'
 if [ ! -d "./styleguide.out/examples" ]; then mkdir -p styleguide.out/examples ; fi
 cd examples && tar -czvf ../styleguide.out/examples/create-react-app.tar.gz ./create-react-app && cd -


### PR DESCRIPTION
*Description of changes:*

This PR is to preinstall the git secrets and typescript to fix the Travis CI build

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
