### PR TITLE
fix(BreadcrumbGroup): Preserve casing of generated links. Fixes #27

### DIFF
--- a/src/components/BreadcrumbGroup/index.test.tsx
+++ b/src/components/BreadcrumbGroup/index.test.tsx
@@ -16,7 +16,7 @@
 
 import * as React from 'react';
 import { MemoryRouter } from 'react-router';
-import { render, getByText, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import BreadcrumbGroup from '.';
 
 describe('BreadcrumbGroup', () => {

--- a/src/components/BreadcrumbGroup/index.test.tsx
+++ b/src/components/BreadcrumbGroup/index.test.tsx
@@ -16,7 +16,7 @@
 
 import * as React from 'react';
 import { MemoryRouter } from 'react-router';
-import { render, getByText } from '@testing-library/react';
+import { render, getByText, screen } from '@testing-library/react';
 import BreadcrumbGroup from '.';
 
 describe('BreadcrumbGroup', () => {
@@ -28,6 +28,21 @@ describe('BreadcrumbGroup', () => {
         );
         expect(getByText('Current')).toBeInTheDocument();
         expect(getByText('Route')).toBeInTheDocument();
+    });
+
+    it('preserves the casing of links when provided no items', () => {
+        const { getAllByRole } = render(
+            <MemoryRouter initialEntries={['/the/current/route/']}>
+                <BreadcrumbGroup />
+            </MemoryRouter>
+        );
+
+        // Casing of links should be preserved
+        const links = getAllByRole('link');
+        expect(links).toHaveLength(3);
+        expect(links[0]).toHaveAttribute('href', '/');
+        expect(links[1]).toHaveAttribute('href', '/the');
+        expect(links[2]).toHaveAttribute('href', '/the/current');
     });
 
     it('renders the items', () => {

--- a/src/components/BreadcrumbGroup/index.tsx
+++ b/src/components/BreadcrumbGroup/index.tsx
@@ -64,15 +64,7 @@ const BreadcrumbGroup = ({ items, rootPath = 'Home', availableRoutes = [] }: Bre
         return (
             <Route>
                 {({ location }: RouteProps) => {
-                    const pathnames = location!.pathname
-                        .split('/')
-                        .map(e =>
-                            e
-                                .split(' ')
-                                .map(s => s.charAt(0).toUpperCase() + s.substring(1))
-                                .join(' ')
-                        )
-                        .filter(e => e);
+                    const pathnames = location!.pathname.split('/').filter(e => e);
                     pathnames.unshift('/');
 
                     return (
@@ -81,18 +73,22 @@ const BreadcrumbGroup = ({ items, rootPath = 'Home', availableRoutes = [] }: Bre
                                 const last = index === pathnames.length - 1;
                                 const segment = pathnames.slice(0, index + 1);
                                 const to = segment.length == 1 ? '/' : `/${segment.slice(1).join('/')}`;
+                                const text = value
+                                    .split(' ')
+                                    .map(s => s.charAt(0).toUpperCase() + s.substring(1))
+                                    .join(' ');
 
                                 return last ? (
                                     <Typography color="inherit" key={to}>
-                                        {pathnames.length == 1 && value === '/' ? rootPath : value}
+                                        {pathnames.length == 1 && value === '/' ? rootPath : text}
                                     </Typography>
                                 ) : matchRoute(to, availableRoutes) ? (
                                     <Link key={to} href={to}>
-                                        {value == '/' ? rootPath : value}
+                                        {value == '/' ? rootPath : text}
                                     </Link>
                                 ) : (
                                     <Typography color="inherit" key={to}>
-                                        {value == '/' ? rootPath : value}
+                                        {value == '/' ? rootPath : text}
                                     </Typography>
                                 );
                             })}


### PR DESCRIPTION
*Issue #, if available:*
#27 

*Description of changes:*
Preserve the casing of generated links in the BreadcrumbGroup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
