### PR TITLE
style(AppLayout): Remove outline style when main content in AppLayout is focussed

### DIFF
--- a/src/layouts/AppLayout/index.tsx
+++ b/src/layouts/AppLayout/index.tsx
@@ -82,6 +82,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
     mainContent: ({ notificationsBoxHeight }: any) => ({
         marginTop: notificationsBoxHeight,
+        '&:focus': {
+            outline: 'none',
+        },
     }),
     menu: {
         [theme.breakpoints.down('xs')]: {


### PR DESCRIPTION
In Chrome, the [default stylesheet adds an outline](https://chromium.googlesource.com/chromium/src/third_party/+/master/blink/renderer/core/html/resources/html.css#1056)
which gets applied to the main content Box. This change removes this outline.

Before:
<img width="1210" alt="Screen Shot 2020-11-02 at 4 20 56 pm" src="https://user-images.githubusercontent.com/1848603/97832701-94a98600-1d27-11eb-8662-1b3dfb6e3c1d.png">

After:
<img width="1213" alt="Screen Shot 2020-11-02 at 4 21 22 pm" src="https://user-images.githubusercontent.com/1848603/97832718-9d9a5780-1d27-11eb-9d03-4778e29c19f5.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
