### PR TITLE
fix: Show error when validation failed in SubForm used inside Wizard

### DIFF
--- a/src/components/FormRenderer/components/Subform/index.tsx
+++ b/src/components/FormRenderer/components/Subform/index.tsx
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.                                                                              *
  ******************************************************************************************************************** */
-import React, { FunctionComponent, memo } from 'react';
+import React, { FunctionComponent, memo, useMemo } from 'react';
 import { useFormApi } from '@data-driven-forms/react-form-renderer';
 import FormSection from '../../../FormSection';
 import Box from '../../../../layouts/Box';
@@ -26,10 +26,19 @@ export interface SubformProps {
     expandable?: boolean;
     expanded?: boolean;
     expandableSectionVariant: ExpandableSectionVariant;
+    showError?: boolean;
 }
 
-const Subform: FunctionComponent<SubformProps> = ({ fields, title, description }) => {
+const Subform: FunctionComponent<SubformProps> = ({ title, description, ...props }) => {
     const { renderForm } = useFormApi();
+
+    const fields = useMemo(() => {
+        return props.fields.map((field: any) => ({
+            ...field,
+            showError: props.showError,
+        }));
+    }, [props.fields, props.showError]);
+
     return (
         <Box mb={2}>
             <FormSection header={title} description={description}>


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-northstar/issues/34

*Description of changes:*

Pass the showError prop from Wizard to SubForm to fields inside SubForm to fix the issue where the error is not shown when validation failed in SubForm used inside Wizard

After the fix, the error will be displayed:

<img width="1552" alt="Screen Shot 2020-11-05 at 08 28 13" src="https://user-images.githubusercontent.com/5362048/98173753-bb460780-1f47-11eb-8c2b-6ede2f8ab2dc.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
