### PR TITLE
fix(input): swap autocomplete and autocorrect property usage

### DIFF
--- a/src/components/Input/Input.md
+++ b/src/components/Input/Input.md
@@ -34,6 +34,10 @@ import Stack from 'aws-northstar/layouts/Stack';
 import Container from 'aws-northstar/layouts/Container';
 
 <Stack>
+    <Container headingVariant='h4' title='Autocomplete disabled'>
+        <Input value="Autocomplete disabled" type="text" autocomplete={false} />
+    </Container>
+
     <Container headingVariant='h4' title='Read Only Input'>
         <Input value="Read only" readonly={true} type="text" />
     </Container>

--- a/src/components/Input/index.stories.tsx
+++ b/src/components/Input/index.stories.tsx
@@ -52,6 +52,9 @@ export const Variations = () => (
             <Input value="Disable" disabled={true} type="text" />
         </Grid>
         <Grid item xs={4}>
+            <Input placeholder="Without autocomplete" type="text" autocomplete={false} />
+        </Grid>
+        <Grid item xs={4}>
             <Input value="Text" invalid={true} type="text" />
         </Grid>
         <Grid item xs={4}>

--- a/src/components/Input/index.test.tsx
+++ b/src/components/Input/index.test.tsx
@@ -60,6 +60,13 @@ describe('Input', () => {
         expect(getByPlaceholderText('input-1')).toHaveAttribute('aria-required', 'true');
     });
 
+    it('should render a "text" input with autocomplete disabled', () => {
+        const { getByPlaceholderText } = render(<Input placeholder="input-1" autocomplete={false} />);
+
+        expect(getByPlaceholderText('input-1').getAttribute('type')).toEqual('text');
+        expect(getByPlaceholderText('input-1').getAttribute('autocomplete')).toEqual('off');
+    });
+
     describe('for search input', () => {
         it('does not render clear button on default', () => {
             const { getByPlaceholderText, queryByTestId } = render(<Input type="search" placeholder="input-1" />);

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -88,8 +88,8 @@ const mapProps = ({
     disableBrowserAutocorrect = false,
     ...props
 }: InputProps): MaterialInputProps => {
-    const autoCorrectString: string = autocomplete ? 'on' : 'off';
-    const autoCompleteString: string = disableBrowserAutocorrect ? 'off' : 'on';
+    const autoCorrectString: string = disableBrowserAutocorrect ? 'off' : 'on';
+    const autoCompleteString: string = autocomplete ? 'on' : 'off';
     const inputProps = {
         'aria-labelledby': props.ariaLabelledby,
         'aria-describedby': props.ariaDescribedby,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The `Input` component uses the props `autocomplete` and  `disableBrowserAutocorrect ` wrongly, this PR swap them to allow client to set them accordingly.

Additionally, the `autocorrect` property is not supported by Material UI ( https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/OutlinedInput/OutlinedInput.js#L144-L286 ) thus is not set to the underlying input once rendered. `autocomplete` works as expected with this fix

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
