### PR TITLE
feat(icon): create icon component to render material ui icons

### DIFF
--- a/src/components/Icon/Icon.md
+++ b/src/components/Icon/Icon.md
@@ -1,0 +1,131 @@
+### Examples
+
+```jsx
+import Icon from 'aws-northstar/components/Icon';
+import Inline from 'aws-northstar/layouts/Inline';
+import Container from 'aws-northstar/layouts/Container';
+
+<Container headingVariant="h4" title="Icons with different size">
+    <Inline>
+        <Icon name="Cloud" fontSize="small" />
+        <Icon name="Cloud" fontSize="default" />
+        <Icon name="Cloud" fontSize="large" />
+        <Icon name="Cloud" style={{ fontSize: '50px' }} />
+    </Inline>
+</Container>;
+```
+
+```jsx
+import Icon from 'aws-northstar/components/Icon';
+import Container from 'aws-northstar/layouts/Container';
+import Inline from 'aws-northstar/layouts/Inline';
+
+<Container headingVariant="h4" title="Icons with different color">
+    <Inline>
+        <Icon name="Dns" fontSize="large" color="inherit" />
+        <Icon name="Dns" fontSize="large" color="primary" />
+        <Icon name="Dns" fontSize="large" color="secondary" style={{ backgroundColor: 'black' }} />
+        <Icon name="Dns" fontSize="large" color="action" />
+        <Icon name="Dns" fontSize="large" color="disabled" />
+        <Icon name="Dns" fontSize="large" color="error" />
+        <Icon name="Dns" fontSize="large" htmlColor="#00FFFF" />
+    </Inline>
+</Container>;
+```
+
+```jsx
+import Icon from 'aws-northstar/components/Icon';
+import Container from 'aws-northstar/layouts/Container';
+import Inline from 'aws-northstar/layouts/Inline';
+
+<Container headingVariant="h4" title="Icons with different variant">
+    <Inline>
+        <Icon name="AccountCircle" fontSize="large" variant="Filled" />
+        <Icon name="AccountCircle" fontSize="large" variant="Outlined" />
+        <Icon name="AccountCircle" fontSize="large" variant="Rounded" />
+        <Icon name="AccountCircle" fontSize="large" variant="TwoTone" />
+        <Icon name="AccountCircle" fontSize="large" variant="Sharp" />
+    </Inline>
+</Container>;
+```
+
+```jsx
+import Icon from 'aws-northstar/components/Icon';
+import Container from 'aws-northstar/layouts/Container';
+import Inline from 'aws-northstar/layouts/Inline';
+
+<Container headingVariant="h4" title="Icons with different variant as icon name">
+    <Inline>
+        <Icon name="AccountCircle" fontSize="large" />
+        <Icon name="AccountCircleOutlined" fontSize="large" />
+        <Icon name="AccountCircleRounded" fontSize="large" />
+        <Icon name="AccountCircleTwoTone" fontSize="large" />
+        <Icon name="AccountCircleSharp" fontSize="large" />
+    </Inline>
+</Container>;
+```
+
+```jsx
+import { useState } from 'react';
+import Icon from 'aws-northstar/components/Icon';
+import Select from 'aws-northstar/components/Select';
+import Input from 'aws-northstar/components/Input';
+import Container from 'aws-northstar/layouts/Container';
+import Inline from 'aws-northstar/layouts/Inline';
+
+const variants = [
+    { label: 'Filled', value: 'Filled' },
+    { label: 'Outlined', value: 'Outlined' },
+    { label: 'Rounded', value: 'Rounded' },
+    { label: 'TwoTone', value: 'TwoTone' },
+    { label: 'Sharp', value: 'Sharp' },
+];
+
+const colors = [
+    { label: 'inherit', value: 'inherit' },
+    { label: 'primary', value: 'primary' },
+    { label: 'secondary', value: 'secondary' },
+    { label: 'action', value: 'action' },
+    { label: 'disabled', value: 'disabled' },
+    { label: 'error', value: 'error' },
+];
+
+const DynamicLoad = () => {
+    const [iconName, setIconName] = useState();
+    const [selectedVariant, setSelectedVariant] = useState();
+    const [selectedColor, setSelectedColor] = useState();
+
+    return (
+        <Container
+            headingVariant="h4"
+            title="Render dynamic icon"
+            footerContent={
+                <Icon
+                    name={iconName}
+                    fontSize="large"
+                    color={(selectedColor || {}).value}
+                    variant={(selectedVariant || {}).value}
+                />
+            }
+        >
+            <Inline>
+                <Input type="text" onChange={name => setIconName(name)} placeholder="icon name. eg: GitHub" />
+                <Select
+                    placeholder="Choose variant"
+                    options={variants}
+                    selectedOption={selectedVariant}
+                    onChange={e => setSelectedVariant(variants.find(q => q.value === e.target.value))}
+                />
+                <Select
+                    placeholder="Choose color"
+                    options={colors}
+                    selectedOption={selectedColor}
+                    onChange={e => setSelectedColor(colors.find(q => q.value === e.target.value))}
+                />
+            </Inline>
+        </Container>
+    );
+};
+
+<DynamicLoad />;
+```

--- a/src/components/Icon/index.stories.tsx
+++ b/src/components/Icon/index.stories.tsx
@@ -1,0 +1,39 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+
+import React from 'react';
+import Icon from '.';
+
+export default {
+    component: Icon,
+    title: 'Icon',
+};
+
+export const DefaultExample = () => <Icon name="AcUnit" />;
+
+export const WithoutVariant = () => <Icon name="MenuRounded" />;
+
+export const OutlinedIcon = () => <Icon name="Cloud" variant="Outlined" />;
+
+export const RoundedIcon = () => <Icon name="Cloud" variant="Rounded" />;
+
+export const TwoToneIcon = () => <Icon name="Cloud" variant="TwoTone" />;
+
+export const SharpIcon = () => <Icon name="Cloud" variant="Sharp" />;
+
+export const htmlColor = () => <Icon name="Cloud" variant="Sharp" htmlColor="#00FFFF" />;
+
+export const FullExample = () => <Icon name="Dns" variant="TwoTone" color="error" fontSize="large" />;

--- a/src/components/Icon/index.test.tsx
+++ b/src/components/Icon/index.test.tsx
@@ -1,0 +1,35 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import Icon from '.';
+
+describe('Icon', () => {
+    it('should render the icon correctly', async () => {
+        const { container } = render(<Icon name="Code" variant="Rounded" />);
+        const svg = container.querySelector('.MuiSvgIcon-root');
+
+        expect(svg).toBeInTheDocument();
+    });
+
+    it('should render the default icon if variant is missing', async () => {
+        const { container } = render(<Icon name="GitHub" variant="Rounded" />);
+        const svg = container.querySelector('.MuiSvgIcon-root');
+
+        expect(svg).toBeInTheDocument();
+    });
+});

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -1,0 +1,82 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+
+import * as icons from '@material-ui/icons';
+import React from 'react';
+
+export type IconVariant = 'Filled' | 'Outlined' | 'Rounded' | 'TwoTone' | 'Sharp';
+
+export interface IconProps {
+    /**
+     * Define the icon name to be rendered
+     */
+    name: keyof typeof icons;
+    /**
+     * Define the icon variant
+     */
+    variant?: IconVariant;
+    /**
+     * Node passed into the SVG element.
+     */
+    children?: React.ReactNode;
+    /**
+     * The color of the component. It supports those theme colors that make sense for this component.
+     * You can use the `htmlColor` prop to apply a color attribute to the SVG element.
+     */
+    color?: 'inherit' | 'primary' | 'secondary' | 'action' | 'disabled' | 'error';
+    /**
+     * The fontSize applied to the icon. Defaults to 24px, but can be configure to inherit font size.
+     */
+    fontSize?: 'inherit' | 'default' | 'small' | 'large';
+    /**
+     * Applies a color attribute to the SVG element.
+     */
+    htmlColor?: string;
+    /**
+     * The shape-rendering attribute. The behavior of the different options is described on the
+     * [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/shape-rendering).
+     * If you are having issues with blurry icons you should investigate this prop.
+     * @document
+     */
+    shapeRendering?: string;
+    /**
+     * Provides a human-readable title for the element that contains it.
+     * https://www.w3.org/TR/SVG-access/#Equivalent
+     */
+    titleAccess?: string;
+    /**
+     * Allows you to redefine what the coordinates without units mean inside an SVG element.
+     * For example, if the SVG element is 500 (width) by 200 (height), and you pass viewBox="0 0 50 20",
+     * this means that the coordinates inside the SVG will go from the top left corner (0,0)
+     * to bottom right (50,20) and each unit will be worth 10px.
+     */
+    viewBox?: string;
+}
+
+export default (props: IconProps) => {
+    const { name, variant, ...rest } = props;
+    // filled is the default icon variant
+    const variantTheme = variant === 'Filled' || !variant ? '' : variant;
+    const iconName = `${name}${variantTheme}`;
+    // support both standard full name or short name with variant
+    let IconComponent = icons[iconName] || icons[name];
+
+    if (!IconComponent) {
+        return null;
+    }
+
+    return <IconComponent {...rest} />;
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -55,3 +55,4 @@ export { default as Toggle } from './Toggle';
 export { default as TokenGroup } from './TokenGroup';
 export { default as TreeView } from './TreeView';
 export { default as Wizard } from './Wizard';
+export { default as Icon } from './Icon';


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*

Add in a new `Icon` component to render material ui icons: https://material-ui.com/components/material-icons/

<img width="449" alt="Screenshot 2020-11-11 at 6 46 56 PM" src="https://user-images.githubusercontent.com/17768831/98802435-4b0b1a80-244e-11eb-9dd6-96e160e56032.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
