### PR TITLE
feat(button): extend usage of Material UI icons to button component

### DIFF
--- a/src/components/Button/Button.md
+++ b/src/components/Button/Button.md
@@ -26,6 +26,9 @@ import Inline from 'aws-northstar/layouts/Inline';
     <Button variant="primary" iconAlign="right" icon="add_plus">Add</Button>
     <Button icon="external">Launch</Button>
     <Button icon="folder" iconAlign="right">Folder</Button>
+    <Button icon="Cloud" iconAlign="right">Cloud</Button>
+    <Button icon="AccountCircleTwoTone" iconAlign="right">Account</Button>
+    <Button icon="Remove" iconAlign="right">Remove</Button>
   </Inline>
 </Container>
 ```

--- a/src/components/Button/components/ButtonIcon/index.test.tsx
+++ b/src/components/Button/components/ButtonIcon/index.test.tsx
@@ -24,4 +24,9 @@ describe('ButtonIcon', () => {
         const { container } = render(<ButtonIcon />);
         expect(container.querySelector('svg')).toBeInTheDocument();
     });
+
+    it('should render and svg icon when Material UI icon is used', () => {
+        const { container } = render(<ButtonIcon type="Cloud" />);
+        expect(container.querySelector('svg')).toBeInTheDocument();
+    });
 });

--- a/src/components/Button/components/ButtonIcon/index.tsx
+++ b/src/components/Button/components/ButtonIcon/index.tsx
@@ -20,8 +20,10 @@ import AddIcon from '@material-ui/icons/Add';
 import FileCopyOutlinedIcon from '@material-ui/icons/FileCopyOutlined';
 import LaunchOutlinedIcon from '@material-ui/icons/LaunchOutlined';
 import RefreshOutlinedIcon from '@material-ui/icons/RefreshOutlined';
+import * as icons from '@material-ui/icons';
+import Icon, { IconName } from '../../../Icon';
 
-export type ButtonIconType = 'add_plus' | 'copy' | 'external' | 'folder' | 'refresh' | 'settings';
+export type ButtonIconType = 'add_plus' | 'copy' | 'external' | 'folder' | 'refresh' | 'settings' | IconName;
 
 export interface ButtonIconProps {
     type?: ButtonIconType;
@@ -40,6 +42,10 @@ export default (props: ButtonIconProps) => {
         case 'refresh':
             return <RefreshOutlinedIcon fontSize="small" />;
         default:
+            if (Object.keys(icons).includes(props.type as string)) {
+                return <Icon name={props.type as IconName} fontSize="small" />;
+            }
+
             return <SettingsOutlinedIcon fontSize="small" />;
     }
 };

--- a/src/components/Button/index.stories.tsx
+++ b/src/components/Button/index.stories.tsx
@@ -65,6 +65,21 @@ export const IconButtonsWithText = () => (
     </Inline>
 );
 
+export const IconButtonsMaterialUIIcons = () => (
+    <Inline>
+        <Button variant={'primary'} icon={'Cloud'} onClick={action('clicked')}>
+            Cloud
+        </Button>
+        <Button variant={'primary'} icon={'AccountCircleTwoTone'} onClick={action('clicked')}>
+            Account
+        </Button>
+        <Button icon={'Remove'} iconAlign="right" onClick={action('clicked')}>
+            Remove
+        </Button>
+        <Button variant={'icon'} label="Dns" icon={'Dns'} onClick={action('clicked')}></Button>
+    </Inline>
+);
+
 export const ReloadButton = () => {
     const [loading, setLoading] = useState(false);
     const [loading2, setLoading2] = useState(false);

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -18,12 +18,13 @@ import * as icons from '@material-ui/icons';
 import React from 'react';
 
 export type IconVariant = 'Filled' | 'Outlined' | 'Rounded' | 'TwoTone' | 'Sharp';
+export type IconName = keyof typeof icons;
 
 export interface IconProps {
     /**
      * Define the icon name to be rendered
      */
-    name: keyof typeof icons;
+    name: IconName;
     /**
      * Define the icon variant
      */


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

as part of the #37 feature, this pull request extend the usage of the Material UI icons to the `button` component as well.

The change is backward compatible and still permit to define the button icons with the alias defined in the component as long as extend it to allow to introduce any Material UI icon as icon name

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
