### PR TITLE
QoL improvement: move automatic testing from pre-commit to pre-push

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged && npm run test:ci",
+      "pre-commit": "lint-staged",
+      "pre-push": "npm run test:ci",
       "commit-msg": "./node_modules/git-conventional-commits/cli.js commit-msg-hook $HUSKY_GIT_PARAMS"
     }
   },


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

Currently, lints and tests run on every **commit**. 
Not only is this redundant and somewhat overly eager, but it also contributes to significant contributor friction during development. 

![sample-pessimistic-tests](https://user-images.githubusercontent.com/705310/99770248-81c5ec80-2b42-11eb-9e64-f9991473e883.gif)

As the code base stands on my machine, unit tests run upwards of `~30s` for 241 tests / 32 suites --- pending optimization of tests, this is expected to grow. This means that on every commit, there is a significant break until work can be resumed.

It is arguably better to have testing performed, instead, on every **push**. Since the repository operates on a PR model, it is enough of a guarantee to have the tests pass on the push, since the push is guaranteed to occur prior to the PR.

**If proactive testing is desired**, the code base already provides the `test:watch` script (`npm run test:watch`), which by default runs ~~tests related to changed all files~~ all tests. I'd say this is the preferred way to tackle the "make sure your changes are tested" problem, instead of enforcing a test run on every commit.

LInting (which is much, much quicker) is kept on the pre-commit hook, however.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
