### PR TITLE
fix(Multiselect): fix wrong behaviour on initial value

### DIFF
--- a/src/components/Multiselect/Multiselect.md
+++ b/src/components/Multiselect/Multiselect.md
@@ -28,3 +28,24 @@ import { awsServices } from '../Autosuggest/data/data';
     />
 </FormField>
 ```
+
+With Initial Values
+```jsx
+import FormField from 'aws-northstar/components/FormField';
+import { awsServices } from '../Autosuggest/data/data';
+
+<FormField label="Form field label" controlId="formFieldId3">
+    <Multiselect
+        options={awsServices}
+        controlId="formFieldId3"
+        ariaDescribedby="This is a description"
+        checkboxes={true}
+        value={[
+            {
+                value: 'EC2',
+                label: 'EC2 - Amazon Elastic Compute Cloud',
+            }
+        ]}
+    />
+</FormField>
+```

--- a/src/components/Multiselect/index.stories.tsx
+++ b/src/components/Multiselect/index.stories.tsx
@@ -48,3 +48,21 @@ export const WithCheckboxes = () => (
         />
     </FormField>
 );
+
+export const WithInitialValue = () => (
+    <FormField label="Form field label" controlId="formFieldId2">
+        <Multiselect
+            options={awsServices}
+            controlId="formFieldId2"
+            ariaDescribedby="This is a description"
+            onChange={action('onChange')}
+            checkboxes={true}
+            value={[
+                {
+                    value: 'EC2',
+                    label: 'EC2 - Amazon Elastic Compute Cloud',
+                },
+            ]}
+        />
+    </FormField>
+);

--- a/src/components/Multiselect/index.tsx
+++ b/src/components/Multiselect/index.tsx
@@ -245,6 +245,7 @@ const Multiselect: FunctionComponent<MultiselectProps> = ({
                 id={controlId}
                 noOptionsText={empty}
                 value={inputValue}
+                getOptionSelected={(opt, v) => opt.value === v.value}
                 open={statusType === 'error' || statusType === 'loading' ? true : open}
                 options={flattenOptions}
                 loadingText={loadingAndErrorText}


### PR DESCRIPTION
*Issue #, if available:*

see #44 

*Description of changes:*

Use `getOptionSelected` to fix bug described here; #44 
as per Material UI docs:

```js
  /**
   * The value of the autocomplete.
   *
   * The value must have reference equality with the option in order to be selected.
   * You can customize the equality behavior with the `getOptionSelected` prop.
   */
  value?: T[];
```

Solved assuming that two items are equal in case their respective value is equal (`getOptionSelected={(opt, v) => opt.value === v.value}` 

Could be fixed differently by selecting the item reference from `flattenOptions` in case the above premise is not totally right

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
