### PR TITLE
feat(card): Allow Card component to define custom typography for the title

### DIFF
--- a/src/components/Card/Card.md
+++ b/src/components/Card/Card.md
@@ -63,3 +63,19 @@ import Box from 'aws-northstar/layouts/Box';
     </Card>
 </Box>
 ```
+
+```jsx
+import Card from 'aws-northstar/components/Card';
+import Container from 'aws-northstar/layouts/Container';
+import Box from 'aws-northstar/layouts/Box';
+
+<Box width='350px'>
+    <Card
+        title="Custom Card Title"
+        subtitle="sub title"
+        titleTypographyProps={{ variant: 'h2', color: 'secondary', align: 'right', gutterBottom: true }}
+    >
+        Text content
+    </Card>
+</Box>
+```

--- a/src/components/Card/index.stories.tsx
+++ b/src/components/Card/index.stories.tsx
@@ -84,3 +84,15 @@ export const WithOnClick = () => (
         </Card>
     </Box>
 );
+
+export const WithTitleTypographyProps = () => (
+    <Box width="350px">
+        <Card
+            title="Card title"
+            subtitle="sub title"
+            titleTypographyProps={{ variant: 'h2', color: 'secondary', align: 'right', gutterBottom: true }}
+        >
+            Show an alert when clicked
+        </Card>
+    </Box>
+);

--- a/src/components/Card/index.test.tsx
+++ b/src/components/Card/index.test.tsx
@@ -45,3 +45,23 @@ describe('Simple card', () => {
         expect(getByText('subtitle')).toBeVisible();
     });
 });
+
+describe('custom header title', () => {
+    it('should render the header using custom titleTypographyProps', () => {
+        const { container, getByText } = render(
+            <Card
+                title="custom title"
+                subtitle="card subtitle"
+                titleTypographyProps={{ variant: 'h2', color: 'secondary', align: 'right', gutterBottom: true }}
+            >
+                <p>Content</p>
+            </Card>
+        );
+
+        expect(getByText('custom title')).toBeVisible();
+        expect(container.getElementsByClassName('MuiTypography-h2')).toHaveLength(1);
+        expect(container.getElementsByClassName('MuiTypography-colorSecondary')).toHaveLength(1);
+        expect(container.getElementsByClassName('MuiTypography-gutterBottom')).toHaveLength(1);
+        expect(container.getElementsByClassName('MuiTypography-alignRight')).toHaveLength(1);
+    });
+});

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -40,7 +40,6 @@ export interface CardProps {
     withHover?: boolean;
     /**
      * These props will be forwarded to the title
-     * (as long as disableTypography is not `true`).
      */
     titleTypographyProps?: any;
     /**

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -39,6 +39,11 @@ export interface CardProps {
      */
     withHover?: boolean;
     /**
+     * These props will be forwarded to the title
+     * (as long as disableTypography is not `true`).
+     */
+    titleTypographyProps?: any;
+    /**
      * Fired when the user clicks on the card.
      */
     onClick?: (event: MouseEvent<HTMLDivElement>) => void;
@@ -71,6 +76,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 const Card: FunctionComponent<CardProps> = ({
     title = '',
     subtitle = '',
+    titleTypographyProps = {},
     children,
     onClick,
     onMouseEnter,
@@ -92,7 +98,7 @@ const Card: FunctionComponent<CardProps> = ({
             onMouseMove={onMouseMove}
             onMouseOut={onMouseOut}
         >
-            <CardHeader title={title} subheader={subtitle} />
+            <CardHeader title={title} subheader={subtitle} titleTypographyProps={titleTypographyProps} />
             {content}
         </MUICard>
     );


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*

Expose the property `titleTypographyProps` available in Material Ui to allow the consumer to define custom title style for `Card` component

eg:

<img width="370" alt="card" src="https://user-images.githubusercontent.com/17768831/100203491-a1dc1e00-2f3d-11eb-8910-5597e2c4883e.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
