### PR TITLE
feat/autosuggest: add in option to define custom icon and custom input

### DIFF
--- a/src/components/Autosuggest/Autosuggest.md
+++ b/src/components/Autosuggest/Autosuggest.md
@@ -149,3 +149,24 @@ import { awsServices } from './data/data';
     </FormField>
 </Container>
 ```
+
+```jsx
+import Autosuggest from 'aws-northstar/components/Autosuggest'
+import Container from 'aws-northstar/layouts/Container';
+import FormField from 'aws-northstar/components/FormField'
+import { awsServices } from './data/data';
+
+<Container headingVariant='h4' title='With free solo (allowing to enter custom text)'>
+    <FormField label="Form field label" controlId="formFieldId1">
+        <Autosuggest
+            icon={'Computer'}
+            filteringType="manual"
+            freeSolo={true}
+            disableClearable={true}
+            options={awsServices}
+            controlId="formFieldId1"
+            ariaDescribedby="This is a description"
+        />
+    </FormField>
+</Container>
+```

--- a/src/components/Autosuggest/Autosuggest.md
+++ b/src/components/Autosuggest/Autosuggest.md
@@ -123,3 +123,29 @@ React.useEffect(() => {
 </Container>
 
 ```
+
+```jsx
+import Autosuggest from 'aws-northstar/components/Autosuggest'
+import Container from 'aws-northstar/layouts/Container';
+import FormField from 'aws-northstar/components/FormField'
+import { awsServices } from './data/data';
+
+<Container headingVariant='h4' title='Without Input Icon'>
+    <FormField label="Form field label" controlId="formFieldId1">
+        <Autosuggest options={awsServices} controlId="formFieldId1" ariaDescribedby="This is a description" icon={false} />
+    </FormField>
+</Container>
+```
+
+```jsx
+import Autosuggest from 'aws-northstar/components/Autosuggest'
+import Container from 'aws-northstar/layouts/Container';
+import FormField from 'aws-northstar/components/FormField'
+import { awsServices } from './data/data';
+
+<Container headingVariant='h4' title='Using a custom Icon'>
+    <FormField label="Form field label" controlId="formFieldId1">
+        <Autosuggest options={awsServices} controlId="formFieldId1" ariaDescribedby="This is a description" icon={'DnsOutlined'} />
+    </FormField>
+</Container>
+```

--- a/src/components/Autosuggest/index.stories.tsx
+++ b/src/components/Autosuggest/index.stories.tsx
@@ -150,3 +150,27 @@ export const AsyncWithError = () => {
         </FormField>
     );
 };
+
+export const WithoutIcon = () => (
+    <FormField label="Form field label" controlId="formFieldId1">
+        <Autosuggest
+            icon={false}
+            options={awsServices}
+            controlId="formFieldId1"
+            ariaDescribedby="This is a description"
+            onChange={action('onChange')}
+        />
+    </FormField>
+);
+
+export const WithCustomIcon = () => (
+    <FormField label="Form field label" controlId="formFieldId1">
+        <Autosuggest
+            icon={'DnsOutlined'}
+            options={awsServices}
+            controlId="formFieldId1"
+            ariaDescribedby="This is a description"
+            onChange={action('onChange')}
+        />
+    </FormField>
+);

--- a/src/components/Autosuggest/index.stories.tsx
+++ b/src/components/Autosuggest/index.stories.tsx
@@ -174,3 +174,19 @@ export const WithCustomIcon = () => (
         />
     </FormField>
 );
+
+export const WithFreeSolo = () => (
+    <FormField label="Form field label" controlId="formFieldId1">
+        <Autosuggest
+            icon={'Computer'}
+            filteringType="manual"
+            freeSolo={true}
+            disableClearable={true}
+            options={awsServices}
+            controlId="formFieldId1"
+            ariaDescribedby="This is a description"
+            onChange={action('onChange')}
+            onInputChange={action('onInputChange')}
+        />
+    </FormField>
+);

--- a/src/components/Autosuggest/index.test.tsx
+++ b/src/components/Autosuggest/index.test.tsx
@@ -200,4 +200,27 @@ describe('Autosuggest', () => {
 
         expect(results).toHaveNoViolations();
     });
+
+    describe('icons', () => {
+        it('should render the component with default icon', () => {
+            const { container } = render(<Autosuggest options={awsServices} placeholder="input-1" />);
+            const svg = container.querySelector('.MuiSvgIcon-colorAction');
+
+            expect(svg).toBeInTheDocument();
+        });
+
+        it('should render the component with custom icon', () => {
+            const { container } = render(<Autosuggest options={awsServices} placeholder="input-1" icon="Dns" />);
+            const svg = container.querySelector('.MuiSvgIcon-colorAction');
+
+            expect(svg).toBeInTheDocument();
+        });
+
+        it('should render the component without an icon', () => {
+            const { container } = render(<Autosuggest options={awsServices} placeholder="input-1" icon={false} />);
+            const svg = container.querySelector('.MuiSvgIcon-colorAction');
+
+            expect(svg).not.toBeInTheDocument();
+        });
+    });
 });

--- a/src/components/Autosuggest/index.tsx
+++ b/src/components/Autosuggest/index.tsx
@@ -53,6 +53,14 @@ export interface AutosuggestProps extends SelectBaseProps, AriaBaseProps {
      * */
     disableBrowserAutocorrect?: boolean;
     /**
+     * If `true`, the Autocomplete is free solo, meaning that the user input is not bound to provided options.
+     */
+    freeSolo?: boolean;
+    /**
+     * If `true`, the input can't be cleared.
+     */
+    disableClearable?: boolean;
+    /**
      * Define the Icon to be used for the text input
      */
     icon?: false | IconName;
@@ -104,6 +112,8 @@ export default function Autosuggest({
     placeholder,
     invalid,
     ariaRequired = false,
+    freeSolo = false,
+    disableClearable = false,
     icon = undefined,
     ariaDescribedby,
     ariaLabelledby,
@@ -204,6 +214,8 @@ export default function Autosuggest({
                 disabled={disabled}
                 autoHighlight
                 popupIcon={null}
+                freeSolo={freeSolo}
+                disableClearable={disableClearable}
                 open={statusType === 'error' || statusType === 'loading' ? true : open}
                 id={controlId}
                 value={inputValue}

--- a/src/components/Autosuggest/index.tsx
+++ b/src/components/Autosuggest/index.tsx
@@ -25,6 +25,7 @@ import LoadingIndicator from '../LoadingIndicator';
 import StatusIndicator from '../StatusIndicator';
 import { AriaBaseProps } from '../../props/common';
 import { SelectBaseProps, SelectOption } from '../Select';
+import Icon, { IconName } from '../Icon';
 
 export interface AutosuggestProps extends SelectBaseProps, AriaBaseProps {
     /**
@@ -51,6 +52,10 @@ export interface AutosuggestProps extends SelectBaseProps, AriaBaseProps {
      * automatically correct user input, such as autocorrect and autocapitalize.
      * */
     disableBrowserAutocorrect?: boolean;
+    /**
+     * Define the Icon to be used for the text input
+     */
+    icon?: false | IconName;
     /**
      * Callback fired when the value changes.
      * */
@@ -99,6 +104,7 @@ export default function Autosuggest({
     placeholder,
     invalid,
     ariaRequired = false,
+    icon = undefined,
     ariaDescribedby,
     ariaLabelledby,
     onChange = () => {},
@@ -184,7 +190,8 @@ export default function Autosuggest({
                 type: 'search',
                 startAdornment: (
                     <InputAdornment position="start">
-                        <SearchIcon color="action" />
+                        {icon === undefined && <SearchIcon color="action" />}
+                        {icon && <Icon name={icon} color="action" />}
                     </InputAdornment>
                 ),
             }}


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

This PR includes the following changes for the `Autosuggest` component:

1. Include option to either remove or customise the Icon by providing a value to the `icon` prop (see image):
1.a: when `icon` prop is not defined, the default Icon will be used (search)
1.b: when  `icon` prop is provided with `false` value, the icon will be removed
2.c: when `icon` prop is one of the allowed Material Icon value  ( https://material-ui.com/components/material-icons/ ) will display it accordingly
2. Expose props `freeSolo` and `disableClearable` to allow the user to define a custom value instead of one of the provided option (eg. use-case such as search autocomplete where the user can either pick a value already available in the dropdown or input a custom one)

Custom Icon:

<img width="553" alt="autosuggest-icons" src="https://user-images.githubusercontent.com/17768831/100327042-b1269e80-3005-11eb-9f21-51cf3215abe2.png">

Free Solo:

![autosuggest](https://user-images.githubusercontent.com/17768831/100328360-660d8b00-3007-11eb-87bd-2f371bcf51e2.gif)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
