### PR TITLE
feat: TimePicker

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -28,6 +28,7 @@ module.exports = {
     moduleNameMapper: {
         '\\.(css|less)$': '<rootDir>/src/__mocks__/styleMock.ts',
     },
+    globalSetup: './jest/jest.globalsetup.js',
     setupFilesAfterEnv: ['./jest/jest.setup.ts'],
     transformIgnorePatterns: [`/node_modules/(?!${esModules})`],
     coverageThreshold: {

--- a/jest/jest.globalsetup.js
+++ b/jest/jest.globalsetup.js
@@ -1,0 +1,19 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+module.exports = async () => {
+    // Set timezone to UTC for tests
+    process.env.TZ = 'UTC';
+};

--- a/src/components/FormRenderer/FormRenderer.md
+++ b/src/components/FormRenderer/FormRenderer.md
@@ -232,6 +232,17 @@ const schema = {
             ],
         },
         {
+            component: componentTypes.TIME_PICKER,
+            name: 'timePicker',
+            label: 'Time picker',
+            isRequired: true,
+            validate: [
+                {
+                    type: validatorTypes.REQUIRED,
+                },
+            ],
+        },
+        {
             component: componentTypes.TREE_VIEW,
             label: 'this is a tree',
             helperText: 'this is a hint',
@@ -298,6 +309,7 @@ const initialValues = {
     ],
     confirm: true,
     datePicker: new Date(2020, 1, 1),
+    timePicker: '2020-01-01T00:00:00Z',
     tree: ['3', '5'],
 };
 
@@ -520,6 +532,17 @@ const schema = {
             component: componentTypes.DATE_PICKER,
             name: 'datePicker',
             label: 'Date picker',
+            isRequired: true,
+            validate: [
+                {
+                    type: validatorTypes.REQUIRED,
+                },
+            ],
+        },
+        {
+            component: componentTypes.TIME_PICKER,
+            name: 'timePicker',
+            label: 'Time picker',
             isRequired: true,
             validate: [
                 {
@@ -1118,6 +1141,17 @@ const schema = {
                             ],
                         },
                         {
+                            component: componentTypes.TIME_PICKER,
+                            name: 'timePicker',
+                            label: 'Time picker',
+                            isRequired: true,
+                            validate: [
+                                {
+                                    type: validatorTypes.REQUIRED,
+                                },
+                            ],
+                        },
+                        {
                             component: componentTypes.CHECKBOX,
                             name: 'confirm',
                             label: 'I understand the terms and condition',
@@ -1219,6 +1253,7 @@ const initialValues = {
     name1: 'name',
     switch: true,
     datePicker: '2020-06-11T14:00:00.000Z',
+    timePicker: '2020-06-11T14:00:00.000Z',
     confirm: true,
     table: [
         { id: 'id0000012', name: 'Engagement 12', createdDate: '2019-11-12' },

--- a/src/components/FormRenderer/components/TimePicker/index.tsx
+++ b/src/components/FormRenderer/components/TimePicker/index.tsx
@@ -1,0 +1,74 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+import React, { FunctionComponent } from 'react';
+import { useFieldApi } from '@data-driven-forms/react-form-renderer';
+import { v4 as uuidv4 } from 'uuid';
+import FormField from '../../../FormField';
+import TimePicker from '../../../TimePicker';
+
+const TimePickerMapping: FunctionComponent = (props: any) => {
+    const {
+        label,
+        description,
+        helperText,
+        isRequired,
+        isDisabled,
+        isReadOnly,
+        placeholder,
+        input,
+        validateOnMount,
+        stretch,
+        showError,
+        meta: { error, submitFailed },
+    } = useFieldApi(props);
+
+    const controlId = input.name || uuidv4();
+    const errorText = ((validateOnMount || submitFailed || showError) && error) || '';
+    // Coerce value (ISO 8601 string) to Date. Handle invalid dates by setting to undefined
+    const dateValue = new Date(input.value);
+    const value = dateValue.toString() !== 'Invalid Date' ? dateValue : undefined;
+    return (
+        <FormField
+            controlId={controlId}
+            label={label}
+            description={description}
+            hintText={helperText}
+            errorText={errorText}
+            stretch={stretch}
+        >
+            <TimePicker
+                {...input}
+                value={value}
+                onChange={(date?: Date) => {
+                    // Coerce to a string for the formrenderer onChange event. Wrap in try catch in case user inputs invalid
+                    // time, eg 99:99.
+                    try {
+                        input.onChange(date?.toISOString());
+                    } catch (e) {
+                        input.onChange(undefined);
+                    }
+                }}
+                placeholder={placeholder}
+                controlId={controlId}
+                disabled={isDisabled}
+                required={isRequired}
+                readonly={isReadOnly}
+            />
+        </FormField>
+    );
+};
+
+export default TimePickerMapping;

--- a/src/components/FormRenderer/index.stories.tsx
+++ b/src/components/FormRenderer/index.stories.tsx
@@ -255,6 +255,17 @@ const baseSchema = {
             ],
         },
         {
+            component: componentTypes.TIME_PICKER,
+            name: 'timePicker',
+            label: 'Time picker',
+            isRequired: true,
+            validate: [
+                {
+                    type: validatorTypes.REQUIRED,
+                },
+            ],
+        },
+        {
             component: componentTypes.TREE_VIEW,
             label: 'this is a tree',
             helperText: 'this is a hint',
@@ -316,6 +327,7 @@ export const WithInitialValues = () => {
         ],
         confirm: true,
         datePicker: new Date(2020, 1, 1),
+        timePicker: '2020-01-01T00:00:00Z',
         tree: ['3', '5'],
     };
 
@@ -871,6 +883,17 @@ const wizardSchema = {
                             ],
                         },
                         {
+                            component: componentTypes.TIME_PICKER,
+                            name: 'timePicker',
+                            label: 'Time picker',
+                            isRequired: true,
+                            validate: [
+                                {
+                                    type: validatorTypes.REQUIRED,
+                                },
+                            ],
+                        },
+                        {
                             component: componentTypes.TREE_VIEW,
                             label: 'this is a tree',
                             helperText: 'this is a hint',
@@ -992,6 +1015,7 @@ export const WizardWithInitialValues = () => {
         name1: 'name',
         switch: true,
         datePicker: '2020-06-11T14:00:00.000Z',
+        timePicker: '2020-06-11T14:00:00.000Z',
         tree: ['3'],
         confirm: true,
         table: [

--- a/src/components/FormRenderer/index.test.tsx
+++ b/src/components/FormRenderer/index.test.tsx
@@ -499,7 +499,52 @@ describe('FormRenderer', () => {
         });
     });
 
-    describe('Raido', () => {
+    describe('TimePicker', () => {
+        const schema = {
+            ...baseSchema,
+            fields: [
+                {
+                    component: componentTypes.TIME_PICKER,
+                    name: 'timePicker',
+                    label: 'Time picker',
+                    isRequired: true,
+                    validate: [
+                        {
+                            type: validatorTypes.REQUIRED,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        it('should render a TimePicker', () => {
+            const { getByLabelText, getByText } = render(
+                <FormRenderer schema={schema} onSubmit={handleSubmit} onCancel={handleCancel} />
+            );
+
+            expect(getByText('Time picker')).toBeVisible();
+            act(() => {
+                fireEvent.change(getByLabelText('Time picker'), { target: { value: '10:35 AM' } });
+            });
+
+            fireEvent.click(getByText('Submit'));
+            expect(handleSubmit).toHaveBeenCalledWith(
+                { timePicker: expect.stringMatching(/.*T10:35:.*Z$/) },
+                expect.any(Object),
+                expect.any(Function)
+            );
+        });
+
+        it('should trigger validation', () => {
+            const { getByText } = render(
+                <FormRenderer schema={schema} onSubmit={handleSubmit} onCancel={handleCancel} />
+            );
+            fireEvent.click(getByText('Submit'));
+            expect(getByText('Required')).toBeVisible();
+        });
+    });
+
+    describe('Radio', () => {
         const schema = {
             ...baseSchema,
             fields: [

--- a/src/components/FormRenderer/index.tsx
+++ b/src/components/FormRenderer/index.tsx
@@ -20,6 +20,7 @@ import TextField from './components/TextField';
 import Checkbox from './components/Checkbox';
 import Radio from './components/Radio';
 import Datepicker from './components/Datepicker';
+import TimePicker from './components/TimePicker';
 import Switch from './components/Switch';
 import Textarea from './components/Textarea';
 import Select from './components/Select';
@@ -38,6 +39,7 @@ const componentMapper = {
     [componentTypes.SUB_FORM]: Subform,
     [componentTypes.RADIO]: Radio,
     [componentTypes.DATE_PICKER]: Datepicker,
+    [componentTypes.TIME_PICKER]: TimePicker,
     [componentTypes.SWITCH]: Switch,
     [componentTypes.TEXTAREA]: Textarea,
     [componentTypes.SELECT]: Select,

--- a/src/components/TimePicker/TimePicker.md
+++ b/src/components/TimePicker/TimePicker.md
@@ -1,0 +1,41 @@
+### Examples
+
+```jsx
+import TimePicker from 'aws-northstar/components/TimePicker';
+import Container from 'aws-northstar/layouts/Container'; 
+<Container headingVariant='h4' title="Default">
+  <TimePicker />
+</Container>
+```
+
+```jsx
+import TimePicker from 'aws-northstar/components/TimePicker';
+import Container from 'aws-northstar/layouts/Container'; 
+<Container headingVariant='h4' title="24h Clock">
+  <TimePicker twentyFourHourClock />
+</Container>
+```
+
+```jsx
+import TimePicker from 'aws-northstar/components/TimePicker';
+import Container from 'aws-northstar/layouts/Container'; 
+<Container headingVariant='h4' title="Disabled">
+  <TimePicker disabled={true}/>
+</Container>
+```
+
+```jsx
+import TimePicker from 'aws-northstar/components/TimePicker';
+import Container from 'aws-northstar/layouts/Container'; 
+<Container headingVariant='h4' title="Read only">
+  <TimePicker readOnly={true} value={new Date()} />
+</Container>
+```
+
+```jsx
+import TimePicker from 'aws-northstar/components/TimePicker';
+import Container from 'aws-northstar/layouts/Container'; 
+<Container headingVariant='h4' title="With placeholder text">
+  <TimePicker placeholder={"custom placeholder"}/>
+</Container>
+```

--- a/src/components/TimePicker/index.stories.tsx
+++ b/src/components/TimePicker/index.stories.tsx
@@ -1,0 +1,32 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+import React from 'react';
+import TimePicker from '.';
+
+export default {
+    component: TimePicker,
+    title: 'TimePicker',
+};
+
+export const Default = () => <TimePicker />;
+
+export const TwentyFourHourClock = () => <TimePicker twentyFourHourClock />;
+
+export const Disabled = () => <TimePicker disabled={true} />;
+
+export const Placeholder = () => <TimePicker placeholder="the custom placeholder" />;
+
+export const ReadOnly = () => <TimePicker readOnly={true} value={new Date()} />;

--- a/src/components/TimePicker/index.test.tsx
+++ b/src/components/TimePicker/index.test.tsx
@@ -1,0 +1,80 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+import React from 'react';
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import TimePicker from '.';
+
+describe('TimePicker', () => {
+    beforeEach(() => jest.clearAllMocks());
+    afterEach(cleanup);
+
+    it('renders a time picker input, empty by default', () => {
+        const { getByRole } = render(<TimePicker />);
+        expect(getByRole('textbox')).toBeInTheDocument();
+        expect(getByRole('textbox')).toHaveValue('');
+    });
+
+    it('renders the time part of a date value', () => {
+        const date = new Date('2020-01-01T22:35:00Z');
+        const { getByRole } = render(<TimePicker value={date} />);
+        expect(getByRole('textbox')).toBeInTheDocument();
+        expect(getByRole('textbox')).toHaveValue('10:35 PM');
+    });
+
+    it('renders a 24h clock', () => {
+        const date = new Date('2020-01-01T22:35:00Z');
+        const { getByRole } = render(<TimePicker twentyFourHourClock value={date} />);
+        expect(getByRole('textbox')).toBeInTheDocument();
+        expect(getByRole('textbox')).toHaveValue('22:35');
+    });
+
+    describe('with a valid input value', () => {
+        it('fires onChange event', () => {
+            const mockOnChange = jest.fn();
+            const { getByRole } = render(<TimePicker onChange={mockOnChange} />);
+            expect(mockOnChange).toHaveBeenCalledTimes(0);
+            fireEvent.change(getByRole('textbox'), { target: { value: '07:30 AM' } });
+            expect(mockOnChange).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('with props', () => {
+        const textboxAttributes = [
+            { propKey: 'ariaRequired', propValue: true, attribute: 'aria-required' },
+            { propKey: 'ariaDescribedby', propValue: 'the description', attribute: 'aria-describedBy' },
+            { propKey: 'ariaLabelledby', propValue: 'the label by', attribute: 'aria-labelledBy' },
+            { propKey: 'label', propValue: 'the label', attribute: 'aria-label' },
+            { propKey: 'controlId', propValue: 'the id', attribute: 'id' },
+            { propKey: 'name', propValue: 'the name', attribute: 'name' },
+        ];
+
+        textboxAttributes.forEach(t => {
+            describe(t.propKey, () => {
+                it(`adds the ${t.attribute} attribute with the value`, () => {
+                    const { getByRole } = render(<TimePicker {...{ [t.propKey]: t.propValue }} />);
+                    expect(getByRole('textbox')).toHaveAttribute(t.attribute, `${t.propValue}`);
+                });
+            });
+        });
+
+        describe('disabled', () => {
+            it('disables the MUI button', () => {
+                const { getByRole } = render(<TimePicker disabled={true} />);
+                expect(getByRole('button')).toHaveAttribute('class', expect.stringContaining('Mui-disabled'));
+            });
+        });
+    });
+});

--- a/src/components/TimePicker/index.tsx
+++ b/src/components/TimePicker/index.tsx
@@ -1,0 +1,147 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+import React, { FunctionComponent, useState } from 'react';
+import { KeyboardTimePicker, MuiPickersUtilsProvider } from '@material-ui/pickers';
+import DateFnsUtils from '@date-io/date-fns';
+
+export interface TimePickerProps {
+    /**
+     * The current input value as a date. Only the time part of the date is relevant
+     * */
+    value?: Date;
+    /**
+     * Placeholder text rendered when the value is an empty string.
+     * */
+    placeholder?: string;
+    /**
+     * Whether to use a 24h clock or one with AM/PM. Default is AM/PM.
+     */
+    twentyFourHourClock?: boolean;
+    /**
+     * The name of the control used in HTML forms.
+     * */
+    name?: string;
+    /**
+     * Specifies that the input should be disabled, preventing the user from modifying the value
+     * and preventing the value from being included in a form submission.
+     * */
+    disabled?: boolean;
+    /**
+     * Specifies that the input should be readonly, preventing the user from modifying the value but including it in a form submission. <br/>
+     * A readonly input can receive focus.
+     * Do not use readonly inputs outside of a form.
+     * */
+    readOnly?: boolean;
+    /**
+     * Allows you to indicate that the control is to be focused as soon as the load event triggers,
+     *  allowing the user to just start typing without having to manually focus the input.
+     * Don't use this option in pages that allow for the field to be scrolled out of the viewport.
+     * */
+    autofocus?: boolean;
+    /**
+     * Id of the internal input.<br/>
+     * Use in conjunction with Form Field to relate a label element "for" attribute to this control for better web accessibility.
+     * See example in <a href='/#/Components/FormField'>FormField</a> for more details.
+     * */
+    controlId?: string;
+    /**
+     * Adds an aria-label on the native input.
+     * */
+    label?: string;
+    /**
+     * Adds aria-labelledby on the native input. <br/>
+     * Use this only with form fields that contain multiple controls under the same label.<br/>
+     * Define a custom id inside the label.<br/>
+     * Refer to that label from every single control under that label using this property.
+     * */
+    ariaLabelledby?: string;
+    /**
+     * Adds aria-describedby on the native input. <br/>
+     * Use this only with form fields that contain multiple controls under the same label. <br/>
+     * Define custom ids inside the description, hint and error text. <br/>
+     * Refer to these from every single control under that label using this property.<br/>
+     * Refer to any other hint/description text that you provide.
+     * */
+    ariaDescribedby?: string;
+    /**
+     * Adds aria-required on the native input
+     * */
+    ariaRequired?: boolean;
+    /**
+     * Fires when the time changes.
+     * */
+    onChange?: (e?: Date) => void;
+}
+
+/**
+ * A time picker control provides a simple way to select a time of day. Time is represented by an ISO 8601 date string,
+ * where the date part can be ignored.
+ */
+const TimePicker: FunctionComponent<TimePickerProps> = ({
+    value,
+    placeholder = 'HH:MM',
+    twentyFourHourClock,
+    name,
+    disabled,
+    readOnly,
+    autofocus,
+    controlId,
+    label,
+    ariaLabelledby,
+    ariaDescribedby,
+    ariaRequired,
+    onChange = () => {},
+}) => {
+    const [selectedDate, setSelectedDate] = useState<Date | null>(value || null);
+
+    const handleDateChange = (date?: any) => {
+        onChange(date);
+        setSelectedDate(date || null);
+    };
+
+    return (
+        <MuiPickersUtilsProvider utils={DateFnsUtils}>
+            <KeyboardTimePicker
+                id={controlId}
+                PopoverProps={{
+                    anchorOrigin: {
+                        vertical: 'bottom',
+                        horizontal: 'left',
+                    },
+                }}
+                variant="inline"
+                inputVariant="outlined"
+                disableToolbar={false}
+                ampm={!twentyFourHourClock}
+                name={name}
+                readOnly={readOnly}
+                value={selectedDate}
+                disabled={disabled}
+                placeholder={placeholder}
+                autoFocus={autofocus}
+                onChange={handleDateChange}
+                inputProps={{
+                    'aria-label': label,
+                    'aria-labelledby': ariaLabelledby,
+                    'aria-describedby': ariaDescribedby,
+                    'aria-required': ariaRequired,
+                }}
+            />
+        </MuiPickersUtilsProvider>
+    );
+};
+
+export default TimePicker;


### PR DESCRIPTION
### Notes
Add a TimePicker component which wraps Material UI's KeyboardTimePicker.

Integrate with FormRenderer for the `time-picker` component type (`componentTypes.TIME_PICKER`).

Times are represented as `Date` objects when using the TimePicker component directly.

In FormRenderer, times are represented as ISO 8601 strings for simpler payloads sent to services.

![timepicker](https://user-images.githubusercontent.com/1848603/102950188-0200b880-451a-11eb-89fc-c9ebb99c2021.png)

### Testing
`npm run test`

Inspected storybook and styleguide.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
