### PR TITLE
fix: ExpandableSection in FormRenderer renders form fields inline - Closes #49

### DIFF
--- a/src/components/FormRenderer/components/ExpandableSection/index.tsx
+++ b/src/components/FormRenderer/components/ExpandableSection/index.tsx
@@ -16,6 +16,7 @@
 import React, { FunctionComponent, useMemo, useState, useEffect } from 'react';
 import { useFormApi, useFieldApi } from '@data-driven-forms/react-form-renderer';
 import ExpandableSection from '../../../ExpandableSection';
+import Stack from '../../../../layouts/Stack';
 import Box from '../../../../layouts/Box';
 
 const ExpandableSectionMapping: FunctionComponent = props => {
@@ -60,7 +61,9 @@ const ExpandableSectionMapping: FunctionComponent = props => {
                     setExpanded(open);
                 }}
             >
-                {renderForm(editedFields)}
+                <Box width="100%">
+                    <Stack>{renderForm(editedFields)}</Stack>
+                </Box>
             </ExpandableSection>
         </Box>
     );

--- a/src/components/FormRenderer/index.stories.tsx
+++ b/src/components/FormRenderer/index.stories.tsx
@@ -390,7 +390,17 @@ export const SubForms = () => {
                     {
                         component: componentTypes.TEXT_FIELD,
                         name: 'name2',
-                        label: 'Name',
+                        label: 'First name',
+                        validate: [
+                            {
+                                type: validatorTypes.REQUIRED,
+                            },
+                        ],
+                    },
+                    {
+                        component: componentTypes.TEXT_FIELD,
+                        name: 'name3',
+                        label: 'Last name',
                         validate: [
                             {
                                 type: validatorTypes.REQUIRED,


### PR DESCRIPTION

*Issue #, if available:*

Closes #49

*Description of changes:*

Render controls inside ExpandableSection in FormRendered Form in a Stack. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
