### PR TITLE
feat: Support programmatically open help panel (Closes #57)

### DIFF
--- a/src/layouts/AppLayout/AppLayout.md
+++ b/src/layouts/AppLayout/AppLayout.md
@@ -1,9 +1,28 @@
+### Open/Close Help Panel
+
+You can invoke the openHelpPanel method available from the AppLayoutContext from your component (must be descendants of AppLayout component) to trigger open of the help panel programmatically. 
+
+```jsx static
+import { useAppLayoutContext } from 'aws-northstar/layouts/AppLayout';
+
+...
+
+const { openHelpPanel } = useAppLayoutContext();
+
+...
+    return (
+        ...
+        <Button onClick={() => openHelpPanel()}>Open Help Panel</Button>
+        ...
+    )
+```
+
 ### Examples
 
 ```jsx
 import { useState } from 'react';
 import { BrowserRouter } from 'react-router-dom';
-import AppLayout, { Notification } from 'aws-northstar/layouts/AppLayout';
+import AppLayout, { Notification, useAppLayoutContext } from 'aws-northstar/layouts/AppLayout';
 import Box from 'aws-northstar/layouts/Box';
 import Header from 'aws-northstar/components/Header';
 import SideNavigation, { SideNavigationItemType } from 'aws-northstar/components/SideNavigation';
@@ -13,6 +32,8 @@ import HelpPanel from 'aws-northstar/components/HelpPanel';
 import Link from 'aws-northstar/components/Link';
 import Text from 'aws-northstar/components/Text';
 import Heading from 'aws-northstar/components/Heading';
+import Stack from 'aws-northstar/layouts/Stack';
+import Button from 'aws-northstar/components/Button';
 
 const header = <Header title="HelloWorld" />;
 const navigationItems = [
@@ -103,13 +124,19 @@ const defaultNotifications = [
         content: 'This is warning content',
         dismissible: true,
     }
-];
+]; 
 
-const mainContent = (
-    <Box bgcolor="grey.300" width="100%" height="1000px">
-        Main Content
-    </Box>
-);
+const MainContent = () => {
+    const { openHelpPanel } = useAppLayoutContext();
+    return (<Box bgcolor="grey.300" width="100%" height="1000px">
+            <Stack>
+                Main Content
+                <Button onClick={() => openHelpPanel()}>Open Help Panel</Button>
+                <Button onClick={() => openHelpPanel(false)}>Close Help Panel</Button>
+            </Stack>
+        </Box>
+    )
+}
 
 const [notifications, setNotifications] = useState(defaultNotifications);
 
@@ -124,7 +151,7 @@ const handleDismiss = (id) => {
         breadcrumbs={breadcrumbGroup}
         notifications={notifications.map(n => ({ ...n, onDismiss: () => handleDismiss(n.id) }))}
     >
-        {mainContent}
+        <MainContent/>
     </AppLayout>
 </BrowserRouter>
 ```

--- a/src/layouts/AppLayout/constants.ts
+++ b/src/layouts/AppLayout/constants.ts
@@ -1,0 +1,17 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+export const LOCAL_STORAGE_KEY_SIDE_NAV_OPEN = 'AppLayout.sideNavigationOpen';
+export const LOCAL_STORAGE_KEY_HELP_PANEL_OPEN = 'AppLayout.helpPanelOpen';

--- a/src/layouts/AppLayout/index.stories.tsx
+++ b/src/layouts/AppLayout/index.stories.tsx
@@ -15,16 +15,18 @@
  ******************************************************************************************************************** */
 import React, { useState, useEffect } from 'react';
 import { action } from '@storybook/addon-actions';
-import AppLayout, { Notification } from '.';
-import Header from '../../components/Header';
-import SideNavigation, { SideNavigationItemType } from '../../components/SideNavigation';
-import HelpPanel from '../../components/HelpPanel';
+import AppLayout, { Notification, useAppLayoutContext } from '.';
 import Badge from '../../components/Badge';
-import BreadcrumbGroup from '../../components/BreadcrumbGroup';
 import Box from '../Box';
-import Link from '../../components/Link';
-import Text from '../../components/Text';
+import BreadcrumbGroup from '../../components/BreadcrumbGroup';
+import Button from '../../components/Button';
+import Header from '../../components/Header';
 import Heading from '../../components/Heading';
+import HelpPanel from '../../components/HelpPanel';
+import Link from '../../components/Link';
+import SideNavigation, { SideNavigationItemType } from '../../components/SideNavigation';
+import Stack from '../Stack';
+import Text from '../../components/Text';
 
 export default {
     component: AppLayout,
@@ -172,6 +174,27 @@ export const WithoutContentPadding = () => {
     return (
         <AppLayout header={header} paddingContentArea={false}>
             {mainContent}
+        </AppLayout>
+    );
+};
+
+const ContentUsingContext = () => {
+    const { openHelpPanel } = useAppLayoutContext();
+    return (
+        <Box bgcolor="grey.300" width="100%" height="1000px">
+            <Stack>
+                Main Content
+                <Button onClick={() => openHelpPanel()}>Open Help Panel</Button>
+                <Button onClick={() => openHelpPanel(false)}>Close Help Panel</Button>
+            </Stack>
+        </Box>
+    );
+};
+
+export const OpenHelpPanel = () => {
+    return (
+        <AppLayout header={header} navigation={navigation} helpPanel={helpPanel}>
+            <ContentUsingContext />
         </AppLayout>
     );
 };

--- a/src/layouts/AppLayout/index.test.tsx
+++ b/src/layouts/AppLayout/index.test.tsx
@@ -14,17 +14,39 @@
   limitations under the License.                                                                              *
  ******************************************************************************************************************** */
 import React from 'react';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, fireEvent, act } from '@testing-library/react';
 import Header from '../../components/Header';
-import AppLayout from '.';
+import AppLayout, { useAppLayoutContext, Notification } from '.';
+
+const mockSetLocalStorage = jest.fn();
+
 jest.mock('react-use-localstorage', () => ({
     __esModule: true,
-    default: () => ['false', () => {}],
+    default: () => ['false', mockSetLocalStorage],
 }));
 
-describe('AppLayout', () => {
-    const header = <Header title="App Title" />;
+const header = <Header title="App Title" />;
 
+const navigation = <div>App Name</div>;
+
+const helpPanel = <div>Help</div>;
+
+const breadcrumbsNode = <div>MockBreadcrumbs</div>;
+
+const notifications: Notification[] = [
+    {
+        id: '1',
+        header: 'Failed to update 1 order',
+        type: 'error',
+        content: 'This is a dismissible error message with a button.',
+        buttonText: 'Retry',
+        onButtonClick: jest.fn(),
+        dismissible: true,
+        onDismiss: jest.fn(),
+    },
+];
+
+describe('AppLayout', () => {
     afterEach(cleanup);
 
     it('renders the headers', () => {
@@ -34,15 +56,94 @@ describe('AppLayout', () => {
         expect(headerTag.textContent).toBe('App Title');
     });
 
-    it('renders the sidebar node', () => {
-        const sidebarNode = <div>MockSidebar</div>;
-        const { getByText } = render(<AppLayout header={header} navigation={sidebarNode} />);
-        expect(getByText('MockSidebar')).toBeInTheDocument();
-    });
-
     it('renders the breadcrumbs node', () => {
-        const breadcrumbsNode = <div>MockBreadcrumbs</div>;
         const { getByText } = render(<AppLayout header={header} breadcrumbs={breadcrumbsNode} />);
         expect(getByText('MockBreadcrumbs')).toBeInTheDocument();
+    });
+
+    describe('NavSideBar', () => {
+        it('renders the nav sidebar node hide', () => {
+            const { getByText } = render(<AppLayout header={header} navigation={navigation} />);
+
+            expect(getByText('App Name')).toBeInTheDocument();
+            expect(getByText('App Name')).not.toBeVisible();
+        });
+
+        it('should open the nav sidebar drawer when users click the button', () => {
+            const { getAllByTestId } = render(<AppLayout header={header} navigation={navigation} />);
+            act(() => {
+                fireEvent.click(getAllByTestId('open-nav-drawer')[1]);
+            });
+
+            expect(mockSetLocalStorage).toBeCalledWith('true');
+        });
+    });
+
+    describe('HelpPanel', () => {
+        it('renders the help panel node', () => {
+            const { getByText } = render(<AppLayout header={header} helpPanel={helpPanel} />);
+
+            expect(getByText('Help')).toBeInTheDocument();
+            expect(getByText('Help')).not.toBeVisible();
+        });
+
+        it('should open the help panel drawer when users click the button', () => {
+            const { getAllByTestId } = render(<AppLayout header={header} navigation={navigation} />);
+            act(() => {
+                fireEvent.click(getAllByTestId('open-nav-drawer')[1]);
+            });
+
+            expect(mockSetLocalStorage).toBeCalledWith('true');
+        });
+
+        it('should trigger open help panel when users call openHelpPanel helper method', () => {
+            const ContentNode = () => {
+                const { openHelpPanel } = useAppLayoutContext();
+                return (
+                    <div>
+                        <button data-testid="trigger-open" onClick={() => openHelpPanel()} />
+                    </div>
+                );
+            };
+            const { getByTestId } = render(
+                <AppLayout header={header} navigation={navigation}>
+                    <ContentNode />
+                </AppLayout>
+            );
+            act(() => {
+                fireEvent.click(getByTestId('trigger-open'));
+            });
+
+            expect(mockSetLocalStorage).toBeCalledWith('true');
+        });
+
+        it('should trigger close help panel when users call openHelpPanel helper method with false', () => {
+            const ContentNode = () => {
+                const { openHelpPanel } = useAppLayoutContext();
+                return (
+                    <div>
+                        <button data-testid="trigger-close" onClick={() => openHelpPanel(false)} />
+                    </div>
+                );
+            };
+            const { getByTestId } = render(
+                <AppLayout header={header} navigation={navigation}>
+                    <ContentNode />
+                </AppLayout>
+            );
+            act(() => {
+                fireEvent.click(getByTestId('trigger-close'));
+            });
+
+            expect(mockSetLocalStorage).toBeCalledWith('false');
+        });
+    });
+
+    describe('Notifications', () => {
+        it('renders notifications', () => {
+            const { getByText } = render(<AppLayout header={header} notifications={notifications} />);
+
+            expect(getByText('Failed to update 1 order')).toBeVisible();
+        });
     });
 });


### PR DESCRIPTION
*Issue #, if available:*

#57 

*Description of changes:*

Add AppLayoutContext to support descendent component to trigger open/close help panel. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
