### PR TITLE
feat(AppLayout): Allow set the height of header for custom header

### DIFF
--- a/src/components/FileUpload/index.tsx
+++ b/src/components/FileUpload/index.tsx
@@ -26,7 +26,7 @@ export interface FileUploadProps extends BaseFormFieldProps {
      */
     multiple?: boolean;
     /**
-     * One or more <a herf='https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#unique_file_type_specifiers' target='blank'>
+     * One or more <a herf='https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#unique_file_type_specifiers' target='_blank'>
      * unique file type specifiers</a> describing file types to allow
      */
     accept?: string;

--- a/src/layouts/AppLayout/index.stories.tsx
+++ b/src/layouts/AppLayout/index.stories.tsx
@@ -199,6 +199,29 @@ export const OpenHelpPanel = () => {
     );
 };
 
+export const CustomHeader = () => {
+    const customHeader = (
+        <Box
+            display="flex"
+            width="100%"
+            height="100px"
+            bgcolor="primary.main"
+            fontSize={56}
+            alignItems="center"
+            paddingLeft={1}
+            paddingY="auto"
+            color="primary.contrastText"
+        >
+            Custom Header
+        </Box>
+    );
+    return (
+        <AppLayout header={customHeader} navigation={navigation} helpPanel={helpPanel} headerHeightInPx={100}>
+            {mainContent}
+        </AppLayout>
+    );
+};
+
 export const WithInprogressOverlay = () => {
     const [inProgress, setInProgress] = useState(false);
     useEffect(() => {

--- a/src/layouts/AppLayout/index.tsx
+++ b/src/layouts/AppLayout/index.tsx
@@ -57,7 +57,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
     main: {
         display: 'flex',
-        height: 'calc(100vh - 65px)',
+        height: ({ headerHeightInPx }: any) => `calc(100vh - ${headerHeightInPx}px)`,
     },
     content: ({ hasSideNavigration, isSideNavigationOpen, hasHelpPanel, isHelpPanelOpen }: any) => ({
         marginTop: 0,
@@ -156,6 +156,10 @@ export interface AppLayoutProps {
     notifications?: Notification[];
     /**Maxinum number of notifications to be displayed*/
     maxNotifications?: number;
+    /**
+     * Height Of Header in pixel when custom header is used.
+     * By default, 65px will be used for the <a href='/#/Components/Header'>NorthStar Header</a>. */
+    headerHeightInPx?: number;
 }
 
 /**
@@ -174,6 +178,7 @@ const AppLayout: FunctionComponent<AppLayoutProps> = ({
     maxNotifications = 2,
     inProgress = false,
     notifications,
+    headerHeightInPx = 65,
 }) => {
     const [isSideNavigationOpen, setIsSideNavigationOpen] = useLocalStorage(LOCAL_STORAGE_KEY_SIDE_NAV_OPEN, 'false');
     const [isHelpPanelOpen, setIsHelpPanelOpen] = useLocalStorage(LOCAL_STORAGE_KEY_HELP_PANEL_OPEN, 'false');
@@ -210,6 +215,7 @@ const AppLayout: FunctionComponent<AppLayoutProps> = ({
         inProgress,
         notificationsBoxHeight,
         mainContentScrollPosition,
+        headerHeightInPx,
     });
 
     const renderNavigationIcon = useCallback(


### PR DESCRIPTION

*Issue #, if available:*

Closes #39 

*Description of changes:*

Add a new prop for AppLayout so that users can set the height of header if a custom header is used.  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
