### PR TITLE
fix(RadioGroup): Centre radio button dots in Safari, fixes #60

### DIFF
--- a/src/components/RadioGroup/index.tsx
+++ b/src/components/RadioGroup/index.tsx
@@ -26,6 +26,9 @@ const useStyles = makeStyles(theme => ({
         textAlign: 'center',
         width: 'fit-content',
     },
+    radio: {
+        transform: 'scale(1)',
+    },
 }));
 
 export interface RadioGroupProps {
@@ -50,7 +53,7 @@ const RadioGroup: FunctionComponent<RadioGroupProps> = ({ name, value, items = [
     const classes = useStyles();
     return (
         <div className={clsx(classes.root, classes.div)}>
-            <MaterialRadioButtonGroup value={value} name={name} onChange={onChange}>
+            <MaterialRadioButtonGroup className={clsx(classes.radio)} value={value} name={name} onChange={onChange}>
                 {items.map((item, index) => (
                     <Fragment key={index}>{item}</Fragment>
                 ))}


### PR DESCRIPTION
*Issue #, if available:*

#60

*Description of changes:* 

Fixes the radio button dot alignment in Safari.

Before:

<img width="289" alt="Screen Shot 2021-02-04 at 11 01 05 am" src="https://user-images.githubusercontent.com/1848603/106826068-3e5b3300-66da-11eb-8f9c-46096e34a3f0.png">

After:

<img width="228" alt="Screen Shot 2021-02-04 at 11 01 13 am" src="https://user-images.githubusercontent.com/1848603/106826092-4e731280-66da-11eb-93ad-50c157223b7b.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
