### PR TITLE
build: Add react libraries (peer-deps) into dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "react"
+      - dependency-name: "@types/react"
+      - dependency-name: "react-dom"
+      - dependency-name: "@types/react-dom"
+      - dependency-name: "react-router"
+      - dependency-name: "@types/react-router"
+      - dependency-name: "react-router-dom"
+      - dependency-name: "@types/react-router-dom"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add react libraries into Dependabot ignore list so that we can support maximum backward compatibilities.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
