### PR TITLE
feat(Popover): Add onChange callback

### DIFF
--- a/src/components/Popover/index.stories.tsx
+++ b/src/components/Popover/index.stories.tsx
@@ -100,14 +100,15 @@ export const Large = () => (
     </Stack>
 );
 
-export const OnChange = () => (
+export const StateChangeCallbacks = () => (
     <Stack>
         <Popover
             position="right"
             size="small"
             triggerType="custom"
             content={<StatusIndicator statusType="positive">Code snippet copied</StatusIndicator>}
-            onChange={action('state changed')}
+            onOpen={action('opened')}
+            onClose={action('closed')}
         >
             <Button>Copy</Button>
         </Popover>

--- a/src/components/Popover/index.stories.tsx
+++ b/src/components/Popover/index.stories.tsx
@@ -20,6 +20,7 @@ import ColumnLayout, { Column } from '../../layouts/ColumnLayout';
 import StatusIndicator from '../StatusIndicator';
 import Button from '../Button';
 import KeyValuePair from '../KeyValuePair';
+import { action } from '@storybook/addon-actions';
 
 export default {
     component: Popover,
@@ -95,6 +96,20 @@ export const Large = () => (
             }
         >
             eth0
+        </Popover>
+    </Stack>
+);
+
+export const OnChange = () => (
+    <Stack>
+        <Popover
+            position="right"
+            size="small"
+            triggerType="custom"
+            content={<StatusIndicator statusType="positive">Code snippet copied</StatusIndicator>}
+            onChange={action('state changed')}
+        >
+            <Button>Copy</Button>
         </Popover>
     </Stack>
 );

--- a/src/components/Popover/index.test.tsx
+++ b/src/components/Popover/index.test.tsx
@@ -14,9 +14,8 @@
   limitations under the License.                                                                              *
  ******************************************************************************************************************** */
 import React from 'react';
-import { getByTestId, getByText, render } from '@testing-library/react';
-import Popover, { PopoverProps } from '.';
-import { BrowserRouter } from 'react-router-dom';
+import { render } from '@testing-library/react';
+import Popover from '.';
 
 describe('Popover', () => {
     const mockOnChange = jest.fn();
@@ -65,17 +64,30 @@ describe('Popover', () => {
         expect(getByText('popover content')).toHaveTextContent('popover content');
     });
 
-    it('calls the onChange callback when the popover is opened and closed', () => {
+    it('calls the onOpen callback when the popover is opened', () => {
         const { getByText, queryByTestId } = render(
-            <Popover header="header text" content="popover content" onChange={mockOnChange}>
+            <Popover header="header text" content="popover content" onOpen={mockOnChange}>
                 <span>Trigger</span>
             </Popover>
         );
         expect(mockOnChange).not.toHaveBeenCalled();
         getByText('Trigger').click();
-        expect(mockOnChange).toHaveBeenNthCalledWith(1, true);
+        expect(mockOnChange).toHaveBeenCalledTimes(1);
         queryByTestId('dismiss-button')!.click();
-        expect(mockOnChange).toHaveBeenNthCalledWith(2, false);
+        expect(mockOnChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls the onClose callback when the popover is closed', () => {
+        const { getByText, queryByTestId } = render(
+            <Popover header="header text" content="popover content" onClose={mockOnChange}>
+                <span>Trigger</span>
+            </Popover>
+        );
+        expect(mockOnChange).not.toHaveBeenCalled();
+        getByText('Trigger').click();
+        expect(mockOnChange).not.toHaveBeenCalled();
+        queryByTestId('dismiss-button')!.click();
+        expect(mockOnChange).toHaveBeenCalledTimes(1);
     });
 
     describe('Dismiss button', () => {

--- a/src/components/Popover/index.test.tsx
+++ b/src/components/Popover/index.test.tsx
@@ -19,6 +19,12 @@ import Popover, { PopoverProps } from '.';
 import { BrowserRouter } from 'react-router-dom';
 
 describe('Popover', () => {
+    const mockOnChange = jest.fn();
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
     it('renders text trigger correctly', () => {
         const { queryByRole, getByRole } = render(
             <Popover triggerType="text">
@@ -57,6 +63,19 @@ describe('Popover', () => {
         );
         getByText('Trigger').click();
         expect(getByText('popover content')).toHaveTextContent('popover content');
+    });
+
+    it('calls the onChange callback when the popover is opened and closed', () => {
+        const { getByText, queryByTestId } = render(
+            <Popover header="header text" content="popover content" onChange={mockOnChange}>
+                <span>Trigger</span>
+            </Popover>
+        );
+        expect(mockOnChange).not.toHaveBeenCalled();
+        getByText('Trigger').click();
+        expect(mockOnChange).toHaveBeenNthCalledWith(1, true);
+        queryByTestId('dismiss-button')!.click();
+        expect(mockOnChange).toHaveBeenNthCalledWith(2, false);
     });
 
     describe('Dismiss button', () => {

--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -136,6 +136,11 @@ export interface PopoverProps {
      * Adds an `aria-label` to the dismiss button for accessibility.
      */
     dismissAriaLabel?: string;
+
+    /**
+     * Optional callback called when the popover is opened or closed
+     */
+    onChange?: (visible: boolean) => void;
 }
 
 /**
@@ -151,6 +156,7 @@ const Popover: FunctionComponent<PopoverProps> = ({
     content,
     dismissAriaLabel,
     header,
+    onChange,
     ...restProps
 }) => {
     const labelledById = useUniqueId('awsui-popover-');
@@ -161,11 +167,13 @@ const Popover: FunctionComponent<PopoverProps> = ({
 
     const onTriggerClick = useCallback(() => {
         setVisible(true);
-    }, []);
+        onChange && onChange(true);
+    }, [onChange]);
 
     const onPopoverClose = useCallback(() => {
         setVisible(false);
-    }, []);
+        onChange && onChange(false);
+    }, [onChange]);
 
     const mapPositionToMuiPopoverOrigins = useCallback(() => {
         let anchorOrigin: MaterialPopoverProps['anchorOrigin'],

--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -138,9 +138,14 @@ export interface PopoverProps {
     dismissAriaLabel?: string;
 
     /**
-     * Optional callback called when the popover is opened or closed
+     * Optional callback called when the popover is opened
      */
-    onChange?: (visible: boolean) => void;
+    onOpen?: () => void;
+
+    /**
+     * Optional callback called when the popover is closed
+     */
+    onClose?: () => void;
 }
 
 /**
@@ -156,7 +161,8 @@ const Popover: FunctionComponent<PopoverProps> = ({
     content,
     dismissAriaLabel,
     header,
-    onChange,
+    onOpen = () => {},
+    onClose = () => {},
     ...restProps
 }) => {
     const labelledById = useUniqueId('awsui-popover-');
@@ -167,13 +173,13 @@ const Popover: FunctionComponent<PopoverProps> = ({
 
     const onTriggerClick = useCallback(() => {
         setVisible(true);
-        onChange && onChange(true);
-    }, [onChange]);
+        onOpen();
+    }, [onOpen]);
 
     const onPopoverClose = useCallback(() => {
         setVisible(false);
-        onChange && onChange(false);
-    }, [onChange]);
+        onClose();
+    }, [onClose]);
 
     const mapPositionToMuiPopoverOrigins = useCallback(() => {
         let anchorOrigin: MaterialPopoverProps['anchorOrigin'],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds an `onChange` callback for users so we can know when the popover was opened and closed, eg to fetch data to display in the popover.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
