### PR TITLE
feat: Add support for arbitrary tab labels

### DIFF
--- a/src/components/Tabs/index.test.tsx
+++ b/src/components/Tabs/index.test.tsx
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.                                                                              *
  ******************************************************************************************************************** */
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 
 import Tabs from '.';

--- a/src/components/Tabs/index.test.tsx
+++ b/src/components/Tabs/index.test.tsx
@@ -13,10 +13,12 @@
   See the License for the specific language governing permissions and
   limitations under the License.                                                                              *
  ******************************************************************************************************************** */
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { render, fireEvent } from '@testing-library/react';
 
 import Tabs from '.';
+
+const THIRD_TAB_LABEL = 'Third tab label';
 
 const tabs = [
     {
@@ -28,6 +30,11 @@ const tabs = [
         label: 'Second tab label',
         id: 'second',
         content: 'Second tab content area',
+    },
+    {
+        label: <div>{THIRD_TAB_LABEL}</div>,
+        id: 'third',
+        content: 'Third tab content area',
     },
 ];
 
@@ -72,7 +79,7 @@ describe('Tabs', () => {
         const onChangeMock = jest.fn();
         const props = { tabs, onChange: onChangeMock };
         const { getByText } = render(<Tabs {...props} />);
-        const tab = getByText(tabs[1].label).closest('button');
+        const tab = getByText(String(tabs[1].label)).closest('button');
         expect(onChangeMock).toBeCalledTimes(0);
 
         if (tab) {
@@ -82,5 +89,13 @@ describe('Tabs', () => {
         expect(getByText(tabs[1].content)).toBeVisible();
         expect(onChangeMock).toBeCalledTimes(1);
         expect(onChangeMock).toHaveBeenCalledWith(tabs[1].id);
+    });
+
+    it('arbitrary content can be rendered in a label', () => {
+        const props = { tabs };
+        const { getByText } = render(<Tabs {...props} />);
+        const labelContent = getByText(THIRD_TAB_LABEL);
+
+        expect(labelContent).toBeVisible();
     });
 });

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -37,7 +37,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 export interface TabItem {
-    label: string;
+    label: string | ReactNode;
     id: string;
     content: ReactNode;
     disabled?: boolean;
@@ -102,13 +102,13 @@ const Tabs = ({ tabs, activeId = '', variant = 'default', onChange }: TabsProps)
             className={clsx(variant === 'container' && classes.noBorder)}
         >
             {tabs.map((tab) => (
-                <Tab key={tab.label} className={classes.tab} label={tab.label} disabled={tab.disabled} />
+                <Tab key={tab.id} className={classes.tab} label={tab.label} disabled={tab.disabled} />
             ))}
         </MuiTabs>
     );
 
     const tabContent = tabs.map((tab, idx) => (
-        <TabPanel key={tab.label} value={value} index={idx}>
+        <TabPanel key={tab.id} value={value} index={idx}>
             {tab.content}
         </TabPanel>
     ));


### PR DESCRIPTION
*Description of changes:*

Add support for arbitrary content within a tab label.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
