### PR TITLE
fix(Input): Fix rendering of falsy values

### DIFF
--- a/src/components/Input/index.test.tsx
+++ b/src/components/Input/index.test.tsx
@@ -83,6 +83,13 @@ describe('Input', () => {
         expect(getByPlaceholderText('input-1').getAttribute('autocomplete')).toEqual('off');
     });
 
+    it('renders falsy values', () => {
+        const { getByPlaceholderText } = render(
+            <Input type="number" placeholder="input-1" onChange={mockOnChange} value={0} />
+        );
+        expect(Number(getByPlaceholderText('input-1').getAttribute('value'))).toEqual(0);
+    });
+
     describe('for search input', () => {
         it('does not render clear button on default', () => {
             const { getByPlaceholderText, queryByTestId } = render(<Input type="search" placeholder="input-1" />);

--- a/src/components/Input/index.test.tsx
+++ b/src/components/Input/index.test.tsx
@@ -87,7 +87,7 @@ describe('Input', () => {
         const { getByPlaceholderText } = render(
             <Input type="number" placeholder="input-1" onChange={mockOnChange} value={0} />
         );
-        expect(Number(getByPlaceholderText('input-1').getAttribute('value'))).toEqual(0);
+        expect(getByPlaceholderText('input-1').getAttribute('value')).toEqual('0');
     });
 
     describe('for search input', () => {

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -125,11 +125,11 @@ const mapProps = ({
  */
 const Input: FunctionComponent<InputProps> = ({ onChange = () => {}, ...props }): ReactElement => {
     const [showClearInputButton, setShowClearInputButton] = React.useState(false);
-    const [inputValue, setInputValue] = React.useState(props.value || '');
+    const [inputValue, setInputValue] = React.useState(props.value === undefined ? '' : props.value);
     const id: string = props.controlId || uuidv4();
 
     useEffect(() => {
-        setInputValue(props.value || '');
+        setInputValue(props.value === undefined ? '' : props.value);
     }, [props.value]);
 
     const handleChange = (value: string): void => {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

If you set the initial value of an input box to `0`, it rendered as an empty string instead!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
