### PR TITLE
feat(FormRenderer): Add isSubmitting boolean to improve form submit UX

### DIFF
--- a/src/components/FormRenderer/FormRenderer.md
+++ b/src/components/FormRenderer/FormRenderer.md
@@ -1355,6 +1355,27 @@ const schema = {
 ```
 
 ```jsx
+import { useCallback } from 'react';
+import FormRenderer, { componentTypes } from 'aws-northstar/components/FormRenderer';
+import Container from 'aws-northstar/layouts/Container';
+
+const schema = {
+    fields: [
+        {
+            component: componentTypes.TEXT_FIELD,
+            name: 'input',
+            isDisabled: true,
+        },
+    ],
+    header: 'Spinner while submitting',
+};
+
+<Container>
+    <FormRenderer schema={schema} onSubmit={console.log} onCancel={console.log} isSubmitting={true} />
+</Container>
+```
+
+```jsx
 import Container from 'aws-northstar/layouts/Container';
 import FormRenderer, { componentTypes, validatorTypes } from 'aws-northstar/components/FormRenderer';
 

--- a/src/components/FormRenderer/components/FormTemplate/index.tsx
+++ b/src/components/FormRenderer/components/FormTemplate/index.tsx
@@ -24,15 +24,15 @@ export interface FormTemplateProps {
     schema: any;
     cancelLabel?: string;
     submitLabel?: string;
-}
-
-export interface AdditionalFormTemplateProps {
     isSubmitting?: boolean;
 }
 
-const buildFormTemplate: (props: AdditionalFormTemplateProps) => FunctionComponent<FormTemplateProps> = ({
+const FormTemplate: FunctionComponent<FormTemplateProps> = ({
+    formFields,
+    schema: { cancelLabel = 'Cancel', submitLabel = 'Submit' },
+    schema,
     isSubmitting,
-}) => ({ formFields, schema: { cancelLabel = 'Cancel', submitLabel = 'Submit' }, schema }) => {
+}) => {
     const { handleSubmit, onCancel } = useFormApi();
 
     const actions = (
@@ -67,4 +67,4 @@ const buildFormTemplate: (props: AdditionalFormTemplateProps) => FunctionCompone
     );
 };
 
-export default buildFormTemplate;
+export default FormTemplate;

--- a/src/components/FormRenderer/components/FormTemplate/index.tsx
+++ b/src/components/FormRenderer/components/FormTemplate/index.tsx
@@ -26,20 +26,23 @@ export interface FormTemplateProps {
     submitLabel?: string;
 }
 
-const FormTemplate: FunctionComponent<FormTemplateProps> = ({
-    formFields,
-    schema: { cancelLabel = 'Cancel', submitLabel = 'Submit' },
-    schema,
-}) => {
+export interface AdditionalFormTemplateProps {
+    isSubmitting?: boolean;
+}
+
+const buildFormTemplate: (props: AdditionalFormTemplateProps) => FunctionComponent<FormTemplateProps> = ({
+    isSubmitting,
+}) => ({ formFields, schema: { cancelLabel = 'Cancel', submitLabel = 'Submit' }, schema }) => {
     const { handleSubmit, onCancel } = useFormApi();
 
     const actions = (
         <Inline spacing="s">
-            <Button variant="link" onClick={onCancel}>
+            <Button variant="link" onClick={onCancel} disabled={isSubmitting}>
                 {cancelLabel}
             </Button>
             <Button
                 variant="primary"
+                loading={isSubmitting}
                 onClick={(event) => {
                     event.preventDefault();
                     handleSubmit(event);
@@ -64,4 +67,4 @@ const FormTemplate: FunctionComponent<FormTemplateProps> = ({
     );
 };
 
-export default FormTemplate;
+export default buildFormTemplate;

--- a/src/components/FormRenderer/index.stories.tsx
+++ b/src/components/FormRenderer/index.stories.tsx
@@ -1116,6 +1116,21 @@ export const FileUploader = () => {
     return <FormRenderer schema={schema} onSubmit={action('Submit')} onCancel={action('Cancel')} />;
 };
 
+export const Submitting = () => {
+    const schema = {
+        fields: [
+            {
+                component: componentTypes.TEXT_FIELD,
+                name: 'input',
+                isDisabled: true,
+            },
+        ],
+        header: 'Spinner while submitting',
+    };
+
+    return <FormRenderer schema={schema} onSubmit={action('Submit')} onCancel={action('Cancel')} isSubmitting={true} />;
+};
+
 export const SimpleMarkdownEditor = () => {
     const schema = {
         submitLabel: 'Save',

--- a/src/components/FormRenderer/index.test.tsx
+++ b/src/components/FormRenderer/index.test.tsx
@@ -16,6 +16,7 @@
 import React from 'react';
 import { render, fireEvent, cleanup, act } from '@testing-library/react';
 import FormRenderer, { componentTypes, validatorTypes } from '.';
+import Button from '../Button';
 
 describe('FormRenderer', () => {
     afterEach(() => {
@@ -85,6 +86,22 @@ describe('FormRenderer', () => {
             );
             expect(getByText('Custom Submit Label')).toBeVisible();
             expect(getByText('Custom Cancel Label')).toBeVisible();
+        });
+
+        it('should show a loading spinner while submitting', () => {
+            const { queryByRole } = render(
+                <FormRenderer schema={schema} onSubmit={handleSubmit} onCancel={handleCancel} isSubmitting={true} />
+            );
+
+            expect(queryByRole('progressbar')).toBeInTheDocument();
+        });
+
+        it('should not show a loading spinner by default', () => {
+            const { queryByRole } = render(
+                <FormRenderer schema={schema} onSubmit={handleSubmit} onCancel={handleCancel} />
+            );
+
+            expect(queryByRole('progressbar')).not.toBeInTheDocument();
         });
     });
 

--- a/src/components/FormRenderer/index.tsx
+++ b/src/components/FormRenderer/index.tsx
@@ -20,7 +20,7 @@ import Custom from './components/Custom';
 import Datepicker from './components/Datepicker';
 import ExpandableSection from './components/ExpandableSection';
 import FieldArray from './components/FieldArray';
-import buildFormTemplate from './components/FormTemplate';
+import FormTemplate from './components/FormTemplate';
 import Radio from './components/Radio';
 import Review from './components/Review';
 import Select from './components/Select';
@@ -85,12 +85,14 @@ const FormRenderer: FunctionComponent<FormRendererProps> = ({
     initialValues,
     customComponentWrapper,
 }) => {
-    const FormTemplate = useMemo(() => buildFormTemplate({ isSubmitting }), [isSubmitting]);
+    const WrappedFormTemplate = useMemo(() => (props: any) => <FormTemplate {...props} isSubmitting={isSubmitting} />, [
+        isSubmitting,
+    ]);
 
     return (
         <FormRender
             componentMapper={{ ...componentMapper, ...customComponentWrapper }}
-            FormTemplate={FormTemplate}
+            FormTemplate={WrappedFormTemplate}
             schema={schema}
             onSubmit={onSubmit}
             onCancel={onCancel}

--- a/src/components/FormRenderer/index.tsx
+++ b/src/components/FormRenderer/index.tsx
@@ -13,14 +13,14 @@
   See the License for the specific language governing permissions and
   limitations under the License.                                                                              *
  ******************************************************************************************************************** */
-import React, { FunctionComponent, ComponentType } from 'react';
+import React, { FunctionComponent, ComponentType, useMemo } from 'react';
 import FormRender, { validatorTypes } from '@data-driven-forms/react-form-renderer';
 import Checkbox from './components/Checkbox';
 import Custom from './components/Custom';
 import Datepicker from './components/Datepicker';
 import ExpandableSection from './components/ExpandableSection';
 import FieldArray from './components/FieldArray';
-import FormTemplate from './components/FormTemplate';
+import buildFormTemplate from './components/FormTemplate';
 import Radio from './components/Radio';
 import Review from './components/Review';
 import Select from './components/Select';
@@ -64,6 +64,8 @@ export interface FormRendererProps {
     onSubmit: (values: any) => void;
     /** A cancel callback, which receives values as the first argument. */
     onCancel?: () => void;
+    /** When true, the submit button is disabled with a loading spinner */
+    isSubmitting?: boolean;
     /** Custom component wrappers*/
     customComponentWrapper?: {
         [componentType: string]: ComponentType;
@@ -79,9 +81,12 @@ const FormRenderer: FunctionComponent<FormRendererProps> = ({
     schema,
     onSubmit,
     onCancel,
+    isSubmitting,
     initialValues,
     customComponentWrapper,
 }) => {
+    const FormTemplate = useMemo(() => buildFormTemplate({ isSubmitting }), [isSubmitting]);
+
     return (
         <FormRender
             componentMapper={{ ...componentMapper, ...customComponentWrapper }}


### PR DESCRIPTION
Add an optional `isSubmitting` prop to `FormRenderer` which adds a loading spinner to the submit
button and disables the cancel button. This gives users visible feedback that the data they have
entered is being submitted.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
