### PR TITLE
feat(Popover): Add 'hover' variant to open the popover when hovering trigger region

### DIFF
--- a/src/components/Popover/Popover.md
+++ b/src/components/Popover/Popover.md
@@ -45,6 +45,29 @@ import StatusIndicator from 'aws-northstar/components/StatusIndicator';
 ```jsx
 import Popover from 'aws-northstar/components/Popover';
 import Stack from 'aws-northstar/layouts/Stack';
+import StatusIndicator from 'aws-northstar/components/StatusIndicator';
+<Stack>
+    <Popover
+        position="bottom"
+        size="medium"
+        header="Hovered"
+        triggerType="text"
+        variant="hover"
+        showDismissButton={false}
+        content={
+            <span>This appears when you hover over the trigger region</span>
+        }
+    >
+        <StatusIndicator statusType="positive">
+            Hover
+        </StatusIndicator>
+    </Popover>
+</Stack>
+```
+
+```jsx
+import Popover from 'aws-northstar/components/Popover';
+import Stack from 'aws-northstar/layouts/Stack';
 import ColumnLayout, { Column } from 'aws-northstar/layouts/ColumnLayout';
 import StatusIndicator from 'aws-northstar/components/StatusIndicator';
 import KeyValuePair from 'aws-northstar/components/KeyValuePair';

--- a/src/components/Popover/index.stories.tsx
+++ b/src/components/Popover/index.stories.tsx
@@ -100,6 +100,22 @@ export const Large = () => (
     </Stack>
 );
 
+export const Hover = () => (
+    <Stack>
+        <Popover
+            position="bottom"
+            size="medium"
+            header="Hovered!"
+            triggerType="text"
+            variant="hover"
+            showDismissButton={false}
+            content={<span>This appears when you hover over the trigger region</span>}
+        >
+            <StatusIndicator statusType="positive">Hover</StatusIndicator>
+        </Popover>
+    </Stack>
+);
+
 export const StateChangeCallbacks = () => (
     <Stack>
         <Popover

--- a/src/components/Popover/index.test.tsx
+++ b/src/components/Popover/index.test.tsx
@@ -14,7 +14,7 @@
   limitations under the License.                                                                              *
  ******************************************************************************************************************** */
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import Popover from '.';
 
 describe('Popover', () => {
@@ -62,6 +62,28 @@ describe('Popover', () => {
         );
         getByText('Trigger').click();
         expect(getByText('popover content')).toHaveTextContent('popover content');
+    });
+
+    it('renders and hides the popover on hover when variant is hover', async () => {
+        const { getByText, queryByText } = render(
+            <Popover header="header text" variant="hover">
+                <span>Trigger</span>
+            </Popover>
+        );
+        expect(queryByText('header text')).toBeNull();
+
+        fireEvent.mouseEnter(getByText('Trigger'));
+
+        await waitFor(() => getByText('header text'));
+        expect(getByText('header text')).toBeInTheDocument();
+
+        fireEvent.mouseLeave(getByText('Trigger'));
+
+        await waitFor(() => {
+            expect(queryByText('header text')).not.toBeInTheDocument();
+        });
+
+        expect(queryByText('header text')).toBeNull();
     });
 
     it('calls the onOpen callback when the popover is opened', () => {

--- a/src/components/Popover/index.test.tsx
+++ b/src/components/Popover/index.test.tsx
@@ -14,7 +14,7 @@
   limitations under the License.                                                                              *
  ******************************************************************************************************************** */
 import React from 'react';
-import { render, fireEvent, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import Popover from '.';
 
 describe('Popover', () => {

--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -110,7 +110,14 @@ export interface PopoverProps {
      * - `text` - Use for inline text triggers.
      * - `custom` - Use for the Northstar Button component.
      */
-    triggerType?: 'text' | 'custom';
+    triggerType?: 'text' | 'custom' | 'hover';
+
+    /**
+     * Specifies how the popover should be opened:
+     * - `click` (default) - click on the trigger region to open the popover
+     * - `hover` - hover the mouse over the trigger region to open the popover
+     */
+    variant?: 'click' | 'hover';
 
     /**
      * Element that triggers the popover when selected by the user.
@@ -157,6 +164,7 @@ const Popover: FunctionComponent<PopoverProps> = ({
     fixedWidth = false,
     size = 'medium',
     triggerType = 'text',
+    variant = 'click',
     children,
     content,
     dismissAriaLabel,
@@ -204,7 +212,9 @@ const Popover: FunctionComponent<PopoverProps> = ({
         // https://github.com/microsoft/TypeScript/issues/36659
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ref: triggerRef as any,
-        onClick: onTriggerClick,
+        onClick: variant !== 'hover' ? onTriggerClick : undefined,
+        onMouseEnter: variant === 'hover' ? onTriggerClick : undefined,
+        onMouseLeave: variant === 'hover' ? onPopoverClose : undefined,
         className: clsx(classes.trigger, classes[`trigger-type-${triggerType}`]),
     };
 
@@ -242,6 +252,7 @@ const Popover: FunctionComponent<PopoverProps> = ({
                         onClose={onPopoverClose}
                         anchorOrigin={anchorOrigin}
                         transformOrigin={transformOrigin}
+                        style={variant === 'hover' ? { pointerEvents: 'none' } : undefined}
                     >
                         <div className={classes.container}>
                             <div

--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -110,7 +110,7 @@ export interface PopoverProps {
      * - `text` - Use for inline text triggers.
      * - `custom` - Use for the Northstar Button component.
      */
-    triggerType?: 'text' | 'custom' | 'hover';
+    triggerType?: 'text' | 'custom';
 
     /**
      * Specifies how the popover should be opened:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add a new `variant` prop to the Popover:

* `click` (default) the existing behaviour where the popover is opened by clicking on the trigger region
* `hover` the popover is opened by hovering the mouse over the trigger region

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
