### PR TITLE
fix(ProgressBar): fix bug with progress bar colour being overridden by mui style

### DIFF
--- a/src/components/ProgressBar/ProgressBar.md
+++ b/src/components/ProgressBar/ProgressBar.md
@@ -15,6 +15,7 @@ import Stack from 'aws-northstar/layouts/Stack';
 
     <Container headingVariant='h4' title="Circular progress bar">
         <ProgressBar label="Circular progress bar completed" variant={'circular'} value={100} displayValue={true} />
+        <ProgressBar label="Circular progress bar empty" variant={'circular'} value={0} displayValue={true} />
     </Container>
 </Stack>    
 ```

--- a/src/components/ProgressBar/index.tsx
+++ b/src/components/ProgressBar/index.tsx
@@ -36,12 +36,12 @@ const useStyles = makeStyles((theme: Theme) => ({
         marginTop: '8px',
     },
     circularColorPrimary: {
-        color: theme.palette.info.dark,
+        color: `${theme.palette.info.dark} !important`,
         position: 'absolute',
         left: 0,
     },
     circularColorBottom: {
-        color: theme.palette.grey[theme.palette.type === 'light' ? 200 : 700],
+        color: `${theme.palette.grey[theme.palette.type === 'light' ? 200 : 700]} !important`,
     },
     barColorPrimary: {
         backgroundColor: theme.palette.info.dark,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Circular progress bars randomly get styled purple by mui, as both the northstar and mui styles have the same precedence (just specified as a style on a class). Address this with `!important` on the northstar colour property.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
