### PR TITLE
refactor(Alert): RENAME Props. Closes #181

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -8,6 +8,7 @@
             "preset": "angular",
             "releaseRules": [
                 {"type": "docs", "scope": "README", "release": "patch"},
+                {"type": "refactor", "message": "RENAME Props*", "release": "minor"},
                 {"type": "feat", "release": "patch"},
                 {"type": "style", "release": "patch"}
             ]

--- a/src/advanced/NotificationButton/index.tsx
+++ b/src/advanced/NotificationButton/index.tsx
@@ -95,7 +95,7 @@ const NotificationButton = ({ notifications = [], onDismissNotification }: Notif
                     borderRadius={false}
                     header={notification.title}
                     type={getNotificationType(notification.severity)}
-                    dismissable={true}
+                    dismissible={true}
                     onDismiss={() => onDismissNotification(notification.id)}
                 >
                     {notification.content}

--- a/src/components/Alert/Alert.md
+++ b/src/components/Alert/Alert.md
@@ -62,25 +62,25 @@ import Container from 'aws-northstar/layouts/Container';
 
 <Stack>
     <Container headingVariant='h4' title='Dismissable Success Alert'>
-        <Alert type="success" dismissable={true}>
+        <Alert type="success" dismissible={true}>
             Content
         </Alert>
     </Container>    
 
     <Container headingVariant='h4' title='Dismissable Info Alert'>
-        <Alert type="info" dismissable={true}>
+        <Alert type="info" dismissible={true}>
             Content
         </Alert>
     </Container>
 
     <Container headingVariant='h4' title='Dismissable Warning Alert'>
-        <Alert type="warning" dismissable={true}>
+        <Alert type="warning" dismissible={true}>
             Content
         </Alert>
     </Container>
 
     <Container headingVariant='h4' title='Dismissable Success Alert'>
-        <Alert type="error" dismissable={true}>
+        <Alert type="error" dismissible={true}>
             Content
         </Alert>
     </Container>
@@ -101,7 +101,7 @@ const [count, setCount] = React.useState(0);
     <Stack>
         <Alert 
             type="success" 
-            dismissable={true} 
+            dismissible={true} 
             buttonText="Enable counter"
             onButtonClick={() => setCount(count+1)}
         >

--- a/src/components/Alert/Alert.md
+++ b/src/components/Alert/Alert.md
@@ -61,25 +61,25 @@ import Stack from 'aws-northstar/layouts/Stack';
 import Container from 'aws-northstar/layouts/Container';
 
 <Stack>
-    <Container headingVariant='h4' title='Dismissable Success Alert'>
+    <Container headingVariant='h4' title='Dismissible Success Alert'>
         <Alert type="success" dismissible={true}>
             Content
         </Alert>
     </Container>    
 
-    <Container headingVariant='h4' title='Dismissable Info Alert'>
+    <Container headingVariant='h4' title='Dismissible Info Alert'>
         <Alert type="info" dismissible={true}>
             Content
         </Alert>
     </Container>
 
-    <Container headingVariant='h4' title='Dismissable Warning Alert'>
+    <Container headingVariant='h4' title='Dismissible Warning Alert'>
         <Alert type="warning" dismissible={true}>
             Content
         </Alert>
     </Container>
 
-    <Container headingVariant='h4' title='Dismissable Success Alert'>
+    <Container headingVariant='h4' title='Dismissible Success Alert'>
         <Alert type="error" dismissible={true}>
             Content
         </Alert>
@@ -97,7 +97,7 @@ import Heading from 'aws-northstar/components/Heading';
 const [count, setCount] = React.useState(0);
 
 
-<Container headingVariant='h4' title='Dismissable Success Alert with Label and Button Click Event'>
+<Container headingVariant='h4' title='Dismissible Success Alert with Label and Button Click Event'>
     <Stack>
         <Alert 
             type="success" 

--- a/src/components/Alert/index.stories.tsx
+++ b/src/components/Alert/index.stories.tsx
@@ -31,10 +31,10 @@ export const Success = () => (
             Pinned
         </Alert>
         <Alert type="success" dismissible={true} onDismiss={action('onDismiss-click')}>
-            Dismissable
+            Dismissible
         </Alert>
         <Alert type="success" dismissible={true} dismissAriaLabel="Quit" onDismiss={action('onDismiss-click')}>
-            Dismissable with dismissible label
+            Dismissible with dismissible label
         </Alert>
         <Alert
             type="success"
@@ -55,10 +55,10 @@ export const Info = () => (
             Pinned
         </Alert>
         <Alert type="info" dismissible={true} onDismiss={action('onDismiss-click')}>
-            Dismissable
+            Dismissible
         </Alert>
         <Alert type="info" dismissible={true} dismissAriaLabel="Quit" onDismiss={action('onDismiss-click')}>
-            Dismissable with dismissible label
+            Dismissible with dismissible label
         </Alert>
         <Alert
             type="info"
@@ -79,10 +79,10 @@ export const Warning = () => (
             Pinned
         </Alert>
         <Alert type="warning" dismissible={true} onDismiss={action('onDismiss-click')}>
-            Dismissable
+            Dismissible
         </Alert>
         <Alert type="warning" dismissible={true} dismissAriaLabel="Quit" onDismiss={action('onDismiss-click')}>
-            Dismissable with dismissible label
+            Dismissible with dismissible label
         </Alert>
         <Alert
             type="warning"
@@ -103,10 +103,10 @@ export const Error = () => (
             Pinned
         </Alert>
         <Alert type="error" dismissible={true} onDismiss={action('onDismiss-click')}>
-            Dismissable
+            Dismissible
         </Alert>
         <Alert type="error" dismissible={true} dismissAriaLabel="Quit" onDismiss={action('onDismiss-click')}>
-            Dismissable with dismissible label
+            Dismissible with dismissible label
         </Alert>
         <Alert
             type="error"

--- a/src/components/Alert/index.stories.tsx
+++ b/src/components/Alert/index.stories.tsx
@@ -30,15 +30,15 @@ export const Success = () => (
         <Alert type="success" header="Success header">
             Pinned
         </Alert>
-        <Alert type="success" dismissable={true} onDismiss={action('onDismiss-click')}>
+        <Alert type="success" dismissible={true} onDismiss={action('onDismiss-click')}>
             Dismissable
         </Alert>
-        <Alert type="success" dismissable={true} dissmissLabel="Quit" onDismiss={action('onDismiss-click')}>
-            Dismissable with dismissable label
+        <Alert type="success" dismissible={true} dismissAriaLabel="Quit" onDismiss={action('onDismiss-click')}>
+            Dismissable with dismissible label
         </Alert>
         <Alert
             type="success"
-            dismissable={true}
+            dismissible={true}
             buttonText="Close"
             onDismiss={action('onDismiss-click')}
             onButtonClick={action('onButtonClick-click')}
@@ -54,15 +54,15 @@ export const Info = () => (
         <Alert type="info" header="Info header">
             Pinned
         </Alert>
-        <Alert type="info" dismissable={true} onDismiss={action('onDismiss-click')}>
+        <Alert type="info" dismissible={true} onDismiss={action('onDismiss-click')}>
             Dismissable
         </Alert>
-        <Alert type="info" dismissable={true} dissmissLabel="Quit" onDismiss={action('onDismiss-click')}>
-            Dismissable with dismissable label
+        <Alert type="info" dismissible={true} dismissAriaLabel="Quit" onDismiss={action('onDismiss-click')}>
+            Dismissable with dismissible label
         </Alert>
         <Alert
             type="info"
-            dismissable={true}
+            dismissible={true}
             buttonText="Close"
             onDismiss={action('onDismiss-click')}
             onButtonClick={action('onButtonClick-click')}
@@ -78,15 +78,15 @@ export const Warning = () => (
         <Alert type="warning" header="Warning header">
             Pinned
         </Alert>
-        <Alert type="warning" dismissable={true} onDismiss={action('onDismiss-click')}>
+        <Alert type="warning" dismissible={true} onDismiss={action('onDismiss-click')}>
             Dismissable
         </Alert>
-        <Alert type="warning" dismissable={true} dissmissLabel="Quit" onDismiss={action('onDismiss-click')}>
-            Dismissable with dismissable label
+        <Alert type="warning" dismissible={true} dismissAriaLabel="Quit" onDismiss={action('onDismiss-click')}>
+            Dismissable with dismissible label
         </Alert>
         <Alert
             type="warning"
-            dismissable={true}
+            dismissible={true}
             buttonText="Close"
             onDismiss={action('onDismiss-click')}
             onButtonClick={action('onButtonClick-click')}
@@ -102,15 +102,15 @@ export const Error = () => (
         <Alert type="error" header="Error header">
             Pinned
         </Alert>
-        <Alert type="error" dismissable={true} onDismiss={action('onDismiss-click')}>
+        <Alert type="error" dismissible={true} onDismiss={action('onDismiss-click')}>
             Dismissable
         </Alert>
-        <Alert type="error" dismissable={true} dissmissLabel="Quit" onDismiss={action('onDismiss-click')}>
-            Dismissable with dismissable label
+        <Alert type="error" dismissible={true} dismissAriaLabel="Quit" onDismiss={action('onDismiss-click')}>
+            Dismissable with dismissible label
         </Alert>
         <Alert
             type="error"
-            dismissable={true}
+            dismissible={true}
             buttonText="Close"
             onDismiss={action('onDismiss-click')}
             onButtonClick={action('onButtonClick-click')}

--- a/src/components/Alert/index.test.tsx
+++ b/src/components/Alert/index.test.tsx
@@ -51,18 +51,18 @@ describe('Alert', () => {
                 });
             });
 
-            describe('and is dismissable', () => {
-                const dismissable = true;
+            describe('and is dismissible', () => {
+                const dismissible = true;
 
                 it('renders the close icon', () => {
-                    const { queryByRole } = render(<Alert type={alertType} dismissable={dismissable} />);
+                    const { queryByRole } = render(<Alert type={alertType} dismissible={dismissible} />);
                     expect(queryByRole('button')).toBeInTheDocument();
                 });
 
                 it('fires dismiss event', () => {
                     const mockDismissEvent = jest.fn();
                     const { getByRole } = render(
-                        <Alert type={alertType} dismissable={dismissable} onDismiss={mockDismissEvent} />
+                        <Alert type={alertType} dismissible={dismissible} onDismiss={mockDismissEvent} />
                     );
                     fireEvent.click(getByRole('button'));
                     expect(mockDismissEvent).toHaveBeenCalledTimes(1);
@@ -72,7 +72,7 @@ describe('Alert', () => {
                     const dismissLabel = 'the label';
                     it('adds the label to the dismiss button', () => {
                         const { queryByLabelText, queryByRole } = render(
-                            <Alert type={alertType} dismissable={dismissable} dissmissLabel={dismissLabel} />
+                            <Alert type={alertType} dismissible={dismissible} dismissAriaLabel={dismissLabel} />
                         );
                         expect(queryByRole('button')).toBeInTheDocument();
                         expect(queryByLabelText(dismissLabel)).toBeInTheDocument();
@@ -83,7 +83,7 @@ describe('Alert', () => {
                     const buttonText = 'the button text';
                     it('renders a custom button with the button text', () => {
                         const { queryByText } = render(
-                            <Alert type={alertType} dismissable={dismissable} buttonText={buttonText} />
+                            <Alert type={alertType} dismissible={dismissible} buttonText={buttonText} />
                         );
                         expect(queryByText(buttonText)).toBeInTheDocument();
                     });
@@ -97,12 +97,12 @@ describe('Alert', () => {
                         expect(mockButtonClickEvent).toHaveBeenCalledTimes(1);
                     });
 
-                    it('fires buttonClick event for dismissable alert', () => {
+                    it('fires buttonClick event for dismissible alert', () => {
                         const mockButtonClickEvent = jest.fn();
                         const { getByText } = render(
                             <Alert
                                 type={alertType}
-                                dismissable={dismissable}
+                                dismissible={dismissible}
                                 buttonText={buttonText}
                                 onButtonClick={mockButtonClickEvent}
                             />

--- a/src/components/Alert/index.tsx
+++ b/src/components/Alert/index.tsx
@@ -55,11 +55,11 @@ export interface AlertProps {
     /** Indicates the type of the message to be displayed. Available options 'error' | 'info' | 'success' | 'warning' */
     type?: AlertType;
     /** Determines whether the alert is displayed to the user or not. */
-    visable?: boolean;
+    visible?: boolean;
     /** If true, the component will include a close button in the UI. */
-    dismissable?: boolean;
+    dismissible?: boolean;
     /** Aria-label for the dismiss button */
-    dissmissLabel?: string;
+    dismissAriaLabel?: string;
     /** Heading text */
     header?: string;
     /** Alert content*/
@@ -81,10 +81,10 @@ export interface AlertProps {
     An alert helps the user know when they need to pay attention to a relatively small piece of information or when they need to take a special action.
 **/
 const Alert: FunctionComponent<AlertProps> = ({
-    visable = true,
+    visible = true,
     onDismiss = () => {},
     onButtonClick = () => {},
-    dissmissLabel = 'Close',
+    dismissAriaLabel = 'Close',
     buttonText = '',
     borderRadius = true,
     ...props
@@ -111,7 +111,7 @@ const Alert: FunctionComponent<AlertProps> = ({
                 {actionButton}
                 {show && (
                     <IconButton
-                        aria-label={dissmissLabel}
+                        aria-label={dismissAriaLabel}
                         onClick={() => {
                             setShow(false);
                             onDismiss();
@@ -122,12 +122,12 @@ const Alert: FunctionComponent<AlertProps> = ({
                 )}
             </>
         ),
-        [actionButton, dissmissLabel, show, onDismiss, setShow]
+        [actionButton, dismissAriaLabel, show, onDismiss, setShow]
     );
 
     const mapProps = useCallback(
-        (alertType: 'dismissable' | 'pinned', { type = 'info' }: AlertProps): MaterialAlertProps => {
-            const dismissableAlertProps: MaterialAlertProps = {
+        (alertType: 'dismissible' | 'pinned', { type = 'info' }: AlertProps): MaterialAlertProps => {
+            const dismissibleAlertProps: MaterialAlertProps = {
                 severity: type,
                 iconMapping,
                 action: closeButton,
@@ -137,7 +137,7 @@ const Alert: FunctionComponent<AlertProps> = ({
                 iconMapping,
                 action: actionButton,
             };
-            return alertType === 'dismissable' ? dismissableAlertProps : pinnedAlertProps;
+            return alertType === 'dismissible' ? dismissibleAlertProps : pinnedAlertProps;
         },
         [closeButton, actionButton]
     );
@@ -164,16 +164,16 @@ const Alert: FunctionComponent<AlertProps> = ({
     );
 
     const renderAlert = useCallback(
-        ({ dismissable, ...props }: AlertProps): ReactNode =>
-            dismissable
-                ? renderAlertBody(props, mapProps('dismissable', props))
+        ({ dismissible, ...props }: AlertProps): ReactNode =>
+            dismissible
+                ? renderAlertBody(props, mapProps('dismissible', props))
                 : renderAlertBody(props, mapProps('pinned', props)),
         [renderAlertBody, mapProps]
     );
 
     return (
         <Box data-testid={props.type} width="100%">
-            {visable && show && renderAlert(props)}
+            {visible && show && renderAlert(props)}
         </Box>
     );
 };


### PR DESCRIPTION
*Issue #, if available:*

#181

*Description of changes:*

Rename the props of Alert:
- dismissable to dismissible
- dissmissLabel to dismissAriaLabel
- visable to visible

Also add the release rule to release as a minor version when the commit message includes RENAME Props 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
