### PR TITLE
fix(ProgressBar): Don't use deprecated prop for CircularProgress

### DIFF
--- a/src/components/ProgressBar/index.tsx
+++ b/src/components/ProgressBar/index.tsx
@@ -139,12 +139,12 @@ const CircularProgressWithLabel: React.FunctionComponent<
         <Box position="relative" display="inline-flex">
             <CircularProgress
                 value={100}
-                variant={'static'}
+                variant="determinate"
                 classes={{ colorPrimary: classes.circularColorBottom }}
                 {...props}
             />
             <CircularProgress
-                variant={'static'}
+                variant="determinate"
                 value={value}
                 classes={{ colorPrimary: classes.circularColorPrimary }}
                 {...props}


### PR DESCRIPTION
This gets rid of the warning message printed in the chrome console:

```
Warning: Failed prop type: Material-UI: `variant="static"` was deprecated. Use `variant="determinate"` instead.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
