### PR TITLE
feat(Table): Disable selection for individual rows

### DIFF
--- a/src/components/Table/Table.md
+++ b/src/components/Table/Table.md
@@ -434,6 +434,150 @@ const tableActions = (
     </Inline>
 );
 
+const disabledItemIds = new Set(['id0000004', 'id0000005', 'id0000007']);
+
+<Table
+    actionGroup={tableActions}
+    tableTitle='Multi Select Table With Selection Disabled for Some Rows'
+    columnDefinitions={columnDefinitions}
+    items={data}
+    onSelectionChange={console.log}
+    isItemDisabled={({ id }) => disabledItemIds.has(id)}
+    getRowId={React.useCallback(data => data.id, [])}
+    sortBy={[{
+        id: 'name',
+        desc: true
+    }]}
+/>
+```
+
+```jsx
+import Table from 'aws-northstar/components/Table';
+import StatusIndicator from 'aws-northstar/components/StatusIndicator';
+import Button from 'aws-northstar/components/Button';
+import Inline from 'aws-northstar/layouts/Inline';
+
+const columnDefinitions = [
+    {
+        id: 'id',
+        width: 200,
+        Header: 'Id',
+        accessor: 'id'
+    },
+    {
+        id: 'name',
+        width: 200,
+        Header: 'Name',
+        accessor: 'name'
+    },
+    {
+        id: 'accounts',
+        width: 200,
+        Header: '# Accounts',
+        accessor: row => row.accounts ? row.accounts.length : 0
+    },
+    {
+        id: 'status',
+        width: 200,
+        Header: 'Status',
+        accessor: 'status',
+        Cell: ({ row  }) => {
+            if (row && row.original) {
+                const status = row.original.status;
+                switch(status) {
+                    case 'active':
+                        return <StatusIndicator  statusType='positive'>Active</StatusIndicator>;
+                    case 'inactive':
+                        return <StatusIndicator  statusType='negative'>Inactive</StatusIndicator>;
+                    default:
+                        return null;
+                }
+            }
+            return null;
+        }
+    }
+];
+
+const data = [
+    {
+        id: 'id0000001',
+        name: 'one',
+        accounts: [],
+        status: 'active'
+    },
+    {
+        id: 'id0000002',
+        name: 'two',
+        accounts: ['acc1', 'acc2'],
+        status: 'active'
+    },
+    {
+        id: 'id0000003',
+        name: 'three',
+        accounts: ['acc1', 'acc2'],
+        status: 'inactive'
+    },
+    {
+        id: 'id0000004',
+        name: 'four',
+        accounts: ['acc1', 'acc2', 'acc3'],
+        status: 'inactive'
+    },
+    {
+        id: 'id0000005',
+        name: 'five',
+        accounts: [],
+        status: 'inactive'
+    },
+    {
+        id: 'id0000006',
+        name: 'six',
+        accounts: [],
+        status: 'active'
+    },
+    {
+        id: 'id0000007',
+        name: 'seven',
+        accounts: [],
+        status: 'active'
+    },
+    {
+        id: 'id0000008',
+        name: 'eight',
+        accounts: [],
+        status: 'active'
+    },
+    {
+        id: 'id0000009',
+        name: 'nine',
+        accounts: [],
+        status: 'active'
+    },
+    {
+        id: 'id0000010',
+        name: 'ten',
+        accounts: [],
+        status: 'active'
+    },
+    {
+        id: 'id0000011',
+        name: 'eleven',
+        accounts: ['acc1', 'acc4', 'acc5', 'acc7'],
+        status: 'active'
+    }
+];
+
+const tableActions = (
+    <Inline>
+        <Button onClick={() => alert('Delete button clicked')}>
+            Delete
+        </Button>
+        <Button variant='primary' onClick={() => alert('Add button clicked')}>
+            Add
+        </Button>
+    </Inline>
+);
+
  <Table
     actionGroup={tableActions}
     tableTitle='Single Select Table'

--- a/src/components/Table/index.stories.tsx
+++ b/src/components/Table/index.stories.tsx
@@ -70,6 +70,21 @@ export const MultiSelect = () => (
     />
 );
 
+export const MultiSelectWithRowsDisabled = () => {
+    const disabledItemIds = new Set(['id0000015', 'id0000016']);
+    return (
+        <Table
+            tableTitle={'Multi Select Table'}
+            columnDefinitions={columnDefinitions}
+            items={shortData}
+            selectedRowIds={['id0000012', 'id0000013']}
+            isItemDisabled={({ id }) => disabledItemIds.has(id)}
+            onSelectionChange={action('onSelectionChange')}
+            getRowId={(data) => data.id}
+        />
+    );
+};
+
 export const SingleSelect = () => (
     <Table
         tableTitle={'Single Select Table'}

--- a/src/components/Table/index.test.tsx
+++ b/src/components/Table/index.test.tsx
@@ -100,10 +100,35 @@ describe('Table', () => {
         );
 
         expect(getByLabelText('Checkbox to select row item')).toBeInTheDocument();
+        expect(getByLabelText('Checkbox to select row item')).toBeEnabled();
+
+        expect(getByLabelText('Checkbox to select all row items')).toBeInTheDocument();
+    });
+
+    it('disables checkboxes for rows where isItemDisabled evaluates to true', () => {
+        const { getByLabelText, queryAllByLabelText } = render(
+            <Table
+                tableTitle={'My Table'}
+                columnDefinitions={columnDefinitions}
+                items={data}
+                disableSortBy={true}
+                disableSettings={true}
+                disablePagination={true}
+                disableFilters={true}
+                isItemDisabled={() => true}
+                disableGroupBy={true}
+            />
+        );
+
+        expect(getByLabelText('Checkbox to select row item')).toBeInTheDocument();
+        expect(getByLabelText('Checkbox to select row item')).toBeDisabled();
+
+        // Should not render the select all box when individual items could be disabled
+        expect(queryAllByLabelText('Checkbox to select all row items')).toHaveLength(0);
     });
 
     it('renders radio buttons', () => {
-        const { getAllByRole } = render(
+        const { getAllByRole, getByRole } = render(
             <Table
                 tableTitle={'My Table'}
                 columnDefinitions={columnDefinitions}
@@ -119,9 +144,30 @@ describe('Table', () => {
         );
 
         expect(getAllByRole('radio')).toHaveLength(1);
+        expect(getByRole('radio')).toBeEnabled();
     });
 
-    it('renders seach input without extra column for search field', () => {
+    it('disables radio buttons for rows where isItemDisabled evaluates to true', () => {
+        const { getAllByRole, getByRole } = render(
+            <Table
+                tableTitle={'My Table'}
+                columnDefinitions={columnDefinitions}
+                items={data}
+                disableSortBy={true}
+                disableSettings={true}
+                disablePagination={true}
+                disableFilters={true}
+                isItemDisabled={() => true}
+                multiSelect={false}
+                disableGroupBy={true}
+            />
+        );
+
+        expect(getAllByRole('radio')).toHaveLength(1);
+        expect(getByRole('radio')).toBeDisabled();
+    });
+
+    it('renders search input without extra column for search field', () => {
         const { getByPlaceholderText, getAllByRole } = render(
             <Table
                 tableTitle={'My Table'}

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -201,6 +201,8 @@ export interface TableBaseOptions<D extends object> {
     getRowId?: (originalRow: D, relativeIndex: number) => string;
     /** The initial columns to sort by */
     sortBy?: SortingRule<string>[];
+    /** Determines whether a given item is disabled. If an item is disabled, the user can't select it. */
+    isItemDisabled?: (item: D) => boolean;
 }
 
 export interface FetchDataOptions {
@@ -251,6 +253,7 @@ export default function Table<D extends object>({
     selectedRowIds = [],
     multiSelect = true,
     getRowId,
+    isItemDisabled,
     sortBy: defaultSortBy = [],
     errorText,
     ...props
@@ -280,7 +283,7 @@ export default function Table<D extends object>({
                 id: '_selection_',
                 width: 50,
                 Header: (props: any) => {
-                    return multiSelect ? (
+                    return multiSelect && !isItemDisabled ? (
                         <Checkbox
                             ariaLabel="Checkbox to select all row items"
                             {...props.getToggleAllRowsSelectedProps()}
@@ -289,17 +292,20 @@ export default function Table<D extends object>({
                 },
                 Cell: (props: any) => {
                     const { row } = props;
+                    const isSelectDisabled = !!isItemDisabled?.(row.original);
                     return (
                         <div>
                             {multiSelect ? (
                                 <Checkbox
                                     ariaLabel="Checkbox to select row item"
                                     {...row.getToggleRowSelectedProps()}
+                                    disabled={isSelectDisabled}
                                 />
                             ) : (
                                 <RadioButton
                                     name="select"
                                     checked={row.isSelected}
+                                    disabled={isSelectDisabled}
                                     onChange={() => {
                                         /** React Table does not support Radio Button natively.
                                          A solution is to toggle all the row off and then toggle the current row on to ensure only current row is selected.


### PR DESCRIPTION
This adds the ability to specify a `isItemDisabled` callback, which disables
selection for rows for which it evaluates to true

Note that we hide the "select all" checkbox when this is specified.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
