### PR TITLE
build(deps-dev): Remove the force resolution of dns-packet

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,6 @@
   "resolutions": {
     "**/webpack/**/terser-webpack-plugin": "3.1.0",
     "trim": "0.0.3",
-    "dns-packet": "5.2.2",
     "browserslist": "4.16.5"
   },
   "browserslist": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6228,12 +6228,13 @@ dns-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz"
   integrity sha1-s55/HabrCnW6nBcySzR1PEfgZU0=
 
-dns-packet@5.2.2, dns-packet@^1.3.1:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-5.2.2.tgz#e4c7d12974cc320b0c0d4b9bbbf68ac151cfe81e"
-  integrity sha512-sQN+vLwC3PvOXiCH/oHcdzML2opFeIdVh8gjjMZrM45n4dR80QF6o3AzInQy6F9Eoc0VJYog4JpQTilt4RFLYQ==
+dns-packet@^1.3.1:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.4.tgz#e3455065824a2507ba886c55a89963bb107dec6f"
+  integrity sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==
   dependencies:
-    ip "^1.1.5"
+    ip "^1.1.0"
+    safe-buffer "^5.0.1"
 
 dns-txt@^2.0.2:
   version "2.0.2"
@@ -9271,9 +9272,9 @@ ip-regex@^2.1.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz"
   integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
-ip@^1.1.5:
+ip@^1.1.0, ip@^1.1.5:
   version "1.1.5"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
 
 ipaddr.js@1.9.1, ipaddr.js@^1.9.0:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Remove the force resolution of dns-packet given that a new version 1.x has been released to address the security warning. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
