### PR TITLE
fix(AppLayout): Remove the spacing caused by the HelpPanel drawer

### DIFF
--- a/src/components/Table/index.stories.tsx
+++ b/src/components/Table/index.stories.tsx
@@ -44,6 +44,7 @@ export const Loading = () => (
 
 export const Simple = () => (
     <Table
+        tableTitle="Table Example"
         columnDefinitions={columnDefinitions}
         items={shortData}
         disableRowSelect={true}

--- a/src/layouts/AppLayout/index.stories.tsx
+++ b/src/layouts/AppLayout/index.stories.tsx
@@ -27,7 +27,8 @@ import Link from '../../components/Link';
 import SideNavigation, { SideNavigationItemType } from '../../components/SideNavigation';
 import Stack from '../Stack';
 import Text from '../../components/Text';
-
+import { Simple as SimpleTable } from '../../components/Table/index.stories';
+import { Default as GeneralInfo } from '../../components/KeyValuePair/index.stories';
 export default {
     component: AppLayout,
     title: 'AppLayout',
@@ -124,12 +125,6 @@ const defaultNotifications: Notification[] = [
     },
 ];
 
-const mainContent = (
-    <Box bgcolor="grey.300" width="100%" height="1000px">
-        Main Content
-    </Box>
-);
-
 export const Default = () => {
     const [notifications, setNotifications] = useState(defaultNotifications);
 
@@ -145,7 +140,10 @@ export const Default = () => {
             breadcrumbs={breadcrumbGroup}
             notifications={notifications.map((n) => ({ ...n, onDismiss: () => handleDismiss(n.id) }))}
         >
-            {mainContent}
+            <Stack>
+                <GeneralInfo />
+                <SimpleTable />
+            </Stack>
         </AppLayout>
     );
 };
@@ -163,7 +161,12 @@ const DynamicHelpPanelSubComponent: React.FunctionComponent<any> = ({ children }
 export const DynamicHelpPanel = () => {
     return (
         <AppLayout header={header} navigation={navigation}>
-            <DynamicHelpPanelSubComponent>{mainContent}</DynamicHelpPanelSubComponent>
+            <DynamicHelpPanelSubComponent>
+                <Stack>
+                    <GeneralInfo />
+                    <SimpleTable />
+                </Stack>
+            </DynamicHelpPanelSubComponent>
         </AppLayout>
     );
 };
@@ -171,19 +174,32 @@ export const DynamicHelpPanel = () => {
 export const WithoutNotifications = () => {
     return (
         <AppLayout header={header} navigation={navigation} helpPanel={helpPanel} breadcrumbs={breadcrumbGroup}>
-            {mainContent}
+            <Stack>
+                <GeneralInfo />
+                <SimpleTable />
+            </Stack>
         </AppLayout>
     );
 };
 
 export const WithoutSidebars = () => {
-    return <AppLayout header={header}>{mainContent}</AppLayout>;
+    return (
+        <AppLayout header={header}>
+            <Stack>
+                <GeneralInfo />
+                <SimpleTable />
+            </Stack>
+        </AppLayout>
+    );
 };
 
 export const WithOnlyHelpPanel = () => {
     return (
         <AppLayout header={header} helpPanel={helpPanel}>
-            {mainContent}
+            <Stack>
+                <GeneralInfo />
+                <SimpleTable />
+            </Stack>
         </AppLayout>
     );
 };
@@ -191,7 +207,10 @@ export const WithOnlyHelpPanel = () => {
 export const WithoutContentPadding = () => {
     return (
         <AppLayout header={header} paddingContentArea={false}>
-            {mainContent}
+            <Stack>
+                <GeneralInfo />
+                <SimpleTable />
+            </Stack>
         </AppLayout>
     );
 };
@@ -235,7 +254,10 @@ export const CustomHeader = () => {
     );
     return (
         <AppLayout header={customHeader} navigation={navigation} helpPanel={helpPanel} headerHeightInPx={100}>
-            {mainContent}
+            <Stack>
+                <GeneralInfo />
+                <SimpleTable />
+            </Stack>
         </AppLayout>
     );
 };
@@ -252,7 +274,10 @@ export const WithInprogressOverlay = () => {
     }, []);
     return (
         <AppLayout header={header} navigation={navigation} breadcrumbs={breadcrumbGroup} inProgress={inProgress}>
-            {mainContent}
+            <Stack>
+                <GeneralInfo />
+                <SimpleTable />
+            </Stack>
         </AppLayout>
     );
 };

--- a/src/layouts/AppLayout/index.tsx
+++ b/src/layouts/AppLayout/index.tsx
@@ -57,6 +57,10 @@ interface StyleProps {
 }
 
 const useStyles = makeStyles<Theme, StyleProps>((theme: Theme) => ({
+    root: {
+        margin: '0',
+        overflow: 'hidden',
+    },
     flashbarContainer: {
         margin: theme.spacing(-4, -4, 2, -4),
     },
@@ -217,7 +221,7 @@ const AppLayout: FunctionComponent<AppLayoutProps> = ({
 
     const classes = useStyles({
         hasSideNavigation: !!navigation,
-        hasHelpPanel: !!helpPanel,
+        hasHelpPanel: !!helpPanelContent,
         isSideNavigationOpen: isSideNavigationOpen === 'true',
         isHelpPanelOpen: isHelpPanelOpen === 'true',
         inProgress,
@@ -274,71 +278,73 @@ const AppLayout: FunctionComponent<AppLayoutProps> = ({
     );
 
     return (
-        <AppLayoutContext.Provider
-            value={{
-                openHelpPanel,
-                setHelpPanelContent,
-            }}
-        >
-            {header}
-            {(navigation || helpPanelContent) && (
-                <Box className={classes.menuBar}>
-                    {navigation && (
-                        <Box className={classes.menuBarNavIcon}>{renderNavigationIcon(classes.menuBarIcon)}</Box>
-                    )}
-                    <Box width="100%" />
-                    {helpPanelContent && (
-                        <Box className={classes.menuBarInfoIcon}>{renderInfoIcon(classes.menuBarIcon)}</Box>
-                    )}
-                </Box>
-            )}
-            <Box className={classes.main}>
-                {navigation && (
-                    <Sidebar
-                        sidebarWidth={WIDTH_SIDEBAR}
-                        isSidebarOpen={isSideNavigationOpen}
-                        setIsSidebarOpen={setIsSideNavigationOpen}
-                        type={SidebarType.SIDE_NAVIGATION}
-                        renderIcon={renderNavigationIcon}
-                    >
-                        {navigation}
-                    </Sidebar>
-                )}
-                <div ref={mainContentRef} className={classes.content} onScroll={handleScroll}>
-                    {notifications && notifications.length > 0 && (
-                        <div ref={notificationsBoxRef} className={classes.notifications}>
-                            <Flashbar items={notifications} maxItemsDisplayed={maxNotifications} />
-                        </div>
-                    )}
-                    <Box
-                        tabIndex={0}
-                        position="relative"
-                        className={clsx(classes.mainContent, { [classes.contentPadding]: !!paddingContentArea })}
-                    >
-                        <Stack spacing="s">
-                            {breadcrumbs && <Box className={classes.breadcrumbsContainer}>{breadcrumbs}</Box>}
-                            <main>{children}</main>
-                        </Stack>
-                        {inProgress && (
-                            <Overlay>
-                                <LoadingIndicator size="large" />
-                            </Overlay>
+        <Box className={classes.root}>
+            <AppLayoutContext.Provider
+                value={{
+                    openHelpPanel,
+                    setHelpPanelContent,
+                }}
+            >
+                {header}
+                {(navigation || helpPanelContent) && (
+                    <Box className={classes.menuBar}>
+                        {navigation && (
+                            <Box className={classes.menuBarNavIcon}>{renderNavigationIcon(classes.menuBarIcon)}</Box>
+                        )}
+                        <Box width="100%" />
+                        {helpPanelContent && (
+                            <Box className={classes.menuBarInfoIcon}>{renderInfoIcon(classes.menuBarIcon)}</Box>
                         )}
                     </Box>
-                </div>
-                {helpPanelContent && (
-                    <Sidebar
-                        sidebarWidth={WIDTH_HELP_PANEL}
-                        isSidebarOpen={isHelpPanelOpen}
-                        setIsSidebarOpen={setIsHelpPanelOpen}
-                        type={SidebarType.HELP_PANEL}
-                        renderIcon={renderInfoIcon}
-                    >
-                        {helpPanelContent}
-                    </Sidebar>
                 )}
-            </Box>
-        </AppLayoutContext.Provider>
+                <Box className={classes.main}>
+                    {navigation && (
+                        <Sidebar
+                            sidebarWidth={WIDTH_SIDEBAR}
+                            isSidebarOpen={isSideNavigationOpen}
+                            setIsSidebarOpen={setIsSideNavigationOpen}
+                            type={SidebarType.SIDE_NAVIGATION}
+                            renderIcon={renderNavigationIcon}
+                        >
+                            {navigation}
+                        </Sidebar>
+                    )}
+                    <div ref={mainContentRef} className={classes.content} onScroll={handleScroll}>
+                        {notifications && notifications.length > 0 && (
+                            <div ref={notificationsBoxRef} className={classes.notifications}>
+                                <Flashbar items={notifications} maxItemsDisplayed={maxNotifications} />
+                            </div>
+                        )}
+                        <Box
+                            tabIndex={0}
+                            position="relative"
+                            className={clsx(classes.mainContent, { [classes.contentPadding]: !!paddingContentArea })}
+                        >
+                            <Stack spacing="s">
+                                {breadcrumbs && <Box className={classes.breadcrumbsContainer}>{breadcrumbs}</Box>}
+                                <main>{children}</main>
+                            </Stack>
+                            {inProgress && (
+                                <Overlay>
+                                    <LoadingIndicator size="large" />
+                                </Overlay>
+                            )}
+                        </Box>
+                    </div>
+                    {helpPanelContent && (
+                        <Sidebar
+                            sidebarWidth={WIDTH_HELP_PANEL}
+                            isSidebarOpen={isHelpPanelOpen}
+                            setIsSidebarOpen={setIsHelpPanelOpen}
+                            type={SidebarType.HELP_PANEL}
+                            renderIcon={renderInfoIcon}
+                        >
+                            {helpPanelContent}
+                        </Sidebar>
+                    )}
+                </Box>
+            </AppLayoutContext.Provider>
+        </Box>
     );
 };
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

There are 2 issues related to the HelpPanel Drawer

- When the HelpPanel content is set dynamically, there is extra spacing in the main content area when the drawer is close. 

<img width="1218" alt="Screen Shot 2021-07-19 at 6 51 41 PM" src="https://user-images.githubusercontent.com/5362048/126132129-a147d6fd-f451-4f8f-ad38-f5013a4743be.png">

-  When the draw is close, the window body overflow.

<img width="1214" alt="Screen Shot 2021-07-19 at 6 51 33 PM" src="https://user-images.githubusercontent.com/5362048/126132202-e1a27078-710f-45fe-a80d-4e9bac47d0e6.png">

This PR addresses this two issues and updates the storybook examples to be more useful:

<img width="1206" alt="Screen Shot 2021-07-19 at 6 55 32 PM" src="https://user-images.githubusercontent.com/5362048/126132700-cc0eb20f-bc5f-4e45-affc-372ae25f2512.png">

<img width="1196" alt="Screen Shot 2021-07-19 at 6 55 40 PM" src="https://user-images.githubusercontent.com/5362048/126132728-670348a8-0278-4510-82f4-21121ede579a.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
