### PR TITLE
docs(Table): Add examples and update docs on how to use getRowId and onSelectChange

### DIFF
--- a/src/components/Table/Table.md
+++ b/src/components/Table/Table.md
@@ -1,6 +1,6 @@
 ### Notes
 
-From release [v1.1.2](https://github.com/aws/aws-northstar/releases/tag/v1.1.2), there may be typescript warning on the columnDefinitions prop. The type can be added to the columnDefinition to suppress the warning. 
+From release [v1.1.2](https://github.com/aws/aws-northstar/releases/tag/v1.1.2), there may be typescript warning on the columnDefinitions prop. The data type can be added to the columnDefinition to suppress the warning. 
 
 ```jsx static
 import Table, { Column } from 'aws-northstar/components/Table';
@@ -28,6 +28,9 @@ const columnDefinition: Column<DataType>[] = [
 ```
 
 ### Examples
+
+More examples are available on [NorthStar storybook](https://storybook.northstar.aws-prototyping.cloud/Table?path=/story/table--simple).
+
 
 ```jsx
 import Table from 'aws-northstar/components/Table';
@@ -322,13 +325,15 @@ const tableActions = (
     </Inline>
 );
 
+const getRowId = React.useCallback(data => data.id, []);
+
 <Table
     actionGroup={tableActions}
     tableTitle='Multi Select Table'
     columnDefinitions={columnDefinitions}
     items={data}
     onSelectionChange={console.log}
-    getRowId={React.useCallback(data => data.id, [])}
+    getRowId={getRowId}
     sortBy={[{
         id: 'name',
         desc: true
@@ -465,6 +470,8 @@ const tableActions = (
 
 const disabledItemIds = new Set(['id0000004', 'id0000005', 'id0000007']);
 
+const getRowId = React.useCallback(data => data.id, []);
+
 <Table
     actionGroup={tableActions}
     tableTitle='Multi Select Table With Selection Disabled for Some Rows'
@@ -472,7 +479,7 @@ const disabledItemIds = new Set(['id0000004', 'id0000005', 'id0000007']);
     items={data}
     onSelectionChange={console.log}
     isItemDisabled={({ id }) => disabledItemIds.has(id)}
-    getRowId={React.useCallback(data => data.id, [])}
+    getRowId={getRowId}
     sortBy={[{
         id: 'name',
         desc: true
@@ -607,14 +614,16 @@ const tableActions = (
     </Inline>
 );
 
- <Table
+const getRowId = React.useCallback(data => data.id, []);
+
+<Table
     actionGroup={tableActions}
     tableTitle='Single Select Table'
     multiSelect={false}
     columnDefinitions={columnDefinitions}
     items={data}
     onSelectionChange={console.log}
-    getRowId={React.useCallback(data => data.id, [])}
+    getRowId={getRowId}
 />
 ```
 

--- a/src/components/Table/index.stories.tsx
+++ b/src/components/Table/index.stories.tsx
@@ -14,7 +14,7 @@
   limitations under the License.                                                                              *
  ******************************************************************************************************************** */
 
-import React, { useCallback, useMemo, useState, useEffect } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import Table, { FetchDataOptions } from '.';
 import Button from '../Button';
@@ -61,19 +61,23 @@ export const Default = () => (
     <Table tableTitle={'Default Table'} columnDefinitions={columnDefinitions} items={shortData} />
 );
 
-export const MultiSelect = () => (
-    <Table
-        tableTitle={'Multi Select Table'}
-        columnDefinitions={columnDefinitions}
-        items={shortData}
-        selectedRowIds={['id0000012', 'id0000013']}
-        onSelectionChange={action('onSelectionChange')}
-        getRowId={(data) => data.id}
-    />
-);
+export const MultiSelect = () => {
+    const getRowId = useCallback((data) => data.id, []);
+    return (
+        <Table
+            tableTitle={'Multi Select Table'}
+            columnDefinitions={columnDefinitions}
+            items={shortData}
+            selectedRowIds={['id0000012', 'id0000013']}
+            onSelectionChange={action('onSelectionChange')}
+            getRowId={getRowId}
+        />
+    );
+};
 
 export const MultiSelectWithRowsDisabled = () => {
     const disabledItemIds = new Set(['id0000015', 'id0000016']);
+    const getRowId = useCallback((data) => data.id, []);
     return (
         <Table
             tableTitle={'Multi Select Table'}
@@ -82,22 +86,25 @@ export const MultiSelectWithRowsDisabled = () => {
             selectedRowIds={['id0000012', 'id0000013']}
             isItemDisabled={({ id }) => disabledItemIds.has(id)}
             onSelectionChange={action('onSelectionChange')}
-            getRowId={(data) => data.id}
+            getRowId={getRowId}
         />
     );
 };
 
-export const SingleSelect = () => (
-    <Table
-        tableTitle={'Single Select Table'}
-        columnDefinitions={columnDefinitions}
-        items={shortData}
-        multiSelect={false}
-        selectedRowIds={['id0000012']}
-        onSelectionChange={action('onSelectionChange')}
-        getRowId={(data) => data.id}
-    />
-);
+export const SingleSelect = () => {
+    const getRowId = useCallback((data) => data.id, []);
+    return (
+        <Table
+            tableTitle={'Single Select Table'}
+            columnDefinitions={columnDefinitions}
+            items={shortData}
+            multiSelect={false}
+            selectedRowIds={['id0000012']}
+            onSelectionChange={action('onSelectionChange')}
+            getRowId={getRowId}
+        />
+    );
+};
 
 export const GroupBy = () => (
     <Table
@@ -136,19 +143,17 @@ export const WithActionGroup = () => {
         return selected?.map((s) => s.id) || [];
     }, [selected]);
 
-    useEffect(() => {
-        console.log('selected', selected);
-    }, [selected]);
+    const getRowId = useCallback((data) => data.id, []);
 
     return (
         <Table
             onSelectionChange={setSelected}
-            tableTitle={'With Action Group'}
+            tableTitle="With Action Group"
             actionGroup={actionGroup}
             columnDefinitions={columnDefinitions}
             multiSelect={false}
             selectedRowIds={selectedRowIds}
-            getRowId={(data) => data.id}
+            getRowId={getRowId}
             items={longData}
         />
     );

--- a/src/components/Table/index.stories.tsx
+++ b/src/components/Table/index.stories.tsx
@@ -14,12 +14,14 @@
   limitations under the License.                                                                              *
  ******************************************************************************************************************** */
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState, useEffect } from 'react';
 import { action } from '@storybook/addon-actions';
 import Table, { FetchDataOptions } from '.';
+import Button from '../Button';
 import longData from './data/long';
 import shortData from './data/short';
 import groupByData from './data/groupBy';
+import { DataType } from './data/type';
 import columnDefinitions from './data/columnDefinitions';
 import orderBy from 'lodash.orderby';
 
@@ -123,29 +125,29 @@ export const Complex = () => (
     />
 );
 
-export const UseState = () => {
-    const [selected, setSelected] = useState();
+export const WithActionGroup = () => {
+    const [selected, setSelected] = useState<DataType[]>();
 
-    const handleSelectChange = useCallback(
-        (value) => {
-            if (value && value.length === 1) {
-                if (selected !== value[0]) {
-                    setSelected(value[0]);
-                }
-            } else {
-                setSelected(undefined);
-            }
-        },
-        [selected, setSelected]
-    );
+    const actionGroup = useMemo(() => {
+        return <Button disabled={!selected || selected.length === 0}>Remove</Button>;
+    }, [selected]);
+
+    const selectedRowIds = useMemo(() => {
+        return selected?.map((s) => s.id) || [];
+    }, [selected]);
+
+    useEffect(() => {
+        console.log('selected', selected);
+    }, [selected]);
 
     return (
         <Table
-            onSelectionChange={handleSelectChange}
-            tableTitle={'Complex Table'}
+            onSelectionChange={setSelected}
+            tableTitle={'With Action Group'}
+            actionGroup={actionGroup}
             columnDefinitions={columnDefinitions}
             multiSelect={false}
-            selectedRowIds={selected && [selected]}
+            selectedRowIds={selectedRowIds}
             getRowId={(data) => data.id}
             items={longData}
         />

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -199,7 +199,7 @@ export interface TableBaseOptions<D extends object> {
      * If the handler is not provided, data is processed automatically.
      * */
     onFetchData?: ((options: FetchDataOptions) => void) | null;
-    /** Returns the id of each row if it is not 'id' */
+    /** Instruct how Table constructs each row's underlying <i>id</i> property. Must be <b>memoized</b>. */
     getRowId?: (originalRow: D, relativeIndex: number) => string;
     /** The initial columns to sort by */
     sortBy?: SortingRule<string>[];
@@ -456,6 +456,7 @@ export default function Table<D extends object>({
         const selected = selectedFlatRows
             .filter((row: Row<D> & Partial<UseGroupByRowProps<D>>) => !row.isGrouped)
             .map((row: Row<D>) => row.original);
+
         onSelectionChange?.(selected);
     }, DEFAULT_DEBOUNCE_TIMER);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Users reported that when use getRowId and onSelectChange, the onSelectChange will be triggered indefinitely. 

After triage, I found out it was because of getRowId is not used properly. So this PR is to add an example and update docs on how to use getRowId and onSelectChange. 

Another consideration is to add a temporary *selected* state, compare the temporary one with the new one, if they are the same, does not trigger the onSelectChange. However, the table is quite complicated already and so try not to add more states. 

The [React Table doc](https://react-table.tanstack.com/docs/api/useTable) also mention the *getRowId* must be **memoized**. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
