### PR TITLE
build: Bump react-markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@types/uuid": "^8.3.1",
     "clsx": "^1.1.1",
     "date-fns": "^2.21.3",
-    "react-markdown": "^6.0.2",
+    "react-markdown": "^6.0.3",
     "react-syntax-highlighter": "^15.4.3",
     "react-table": "7.7.0",
     "react-use-localstorage": "^3.4.1",

--- a/src/components/MarkdownViewer/index.tsx
+++ b/src/components/MarkdownViewer/index.tsx
@@ -29,7 +29,7 @@ export interface MarkdownViewerProps {
 }
 
 const components: ReactMarkdownOptions['components'] = {
-    code: ({ node, inline, className, children, ...props }) => {
+    code: ({ node, inline, className, children, ref, ...props }) => {
         const match = /language-(\w+)/.exec(className || '');
         const value = String(children).replace(/\n$/, '');
         return !inline && match ? (

--- a/yarn.lock
+++ b/yarn.lock
@@ -13767,16 +13767,16 @@ react-map-gl@^6.1.16:
     resize-observer-polyfill "^1.5.1"
     viewport-mercator-project "^7.0.3"
 
-react-markdown@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-6.0.2.tgz#d89be45c278b1e5f0196f851fffb11e30c69f027"
-  integrity sha512-Et2AjXAsbmPP1nLQQRqmVgcqzfwcz8uQJ8VAdADs8Nk/aaUA0YeU9RDLuCtD+GwajCnm/+Iiu2KPmXzmD/M3vA==
+react-markdown@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-6.0.3.tgz#625ec767fa321d91801129387e7d31ee0cb99254"
+  integrity sha512-kQbpWiMoBHnj9myLlmZG9T1JdoT/OEyHK7hqM6CqFT14MAkgWiWBUYijLyBmxbntaN6dCDicPcUhWhci1QYodg==
   dependencies:
     "@types/hast" "^2.0.0"
     "@types/unist" "^2.0.3"
     comma-separated-tokens "^1.0.0"
     prop-types "^15.7.2"
-    property-information "^5.0.0"
+    property-information "^5.3.0"
     react-is "^17.0.0"
     remark-parse "^9.0.0"
     remark-rehype "^8.0.0"


### PR DESCRIPTION
Bump react-markdown

close #293 

There is incompatibility between **ref** types. I suppose that we can just skip passing `code ref` to `SyntaxHighlighter`
