### PR TITLE
fix(FormRenderer): Honour isSubmitting prop in Wizard

### DIFF
--- a/src/components/FormRenderer/components/FormTemplate/index.tsx
+++ b/src/components/FormRenderer/components/FormTemplate/index.tsx
@@ -19,12 +19,9 @@ import Form from '../../../Form';
 import Button from '../../../Button';
 import Inline from '../../../../layouts/Inline';
 import { componentTypes, RenderProps } from '../../types';
+import { useFormRendererContext } from '../../index';
 
-export interface FormTemplateProps extends RenderProps {
-    isSubmitting?: boolean;
-}
-
-const FormTemplate: FunctionComponent<RenderProps> = ({ formFields, schema, isSubmitting }) => {
+const FormTemplate: FunctionComponent<RenderProps> = ({ formFields, schema }) => {
     const { handleSubmit, onCancel, onReset } = useFormApi();
     const {
         cancelLabel = 'Cancel',
@@ -36,6 +33,7 @@ const FormTemplate: FunctionComponent<RenderProps> = ({ formFields, schema, isSu
         header,
         description,
     } = schema;
+    const { isSubmitting } = useFormRendererContext();
 
     const actions = (
         <Inline spacing="s">

--- a/src/components/FormRenderer/components/Wizard/components/WizardStep/index.tsx
+++ b/src/components/FormRenderer/components/Wizard/components/WizardStep/index.tsx
@@ -28,6 +28,7 @@ export interface WizardStepProps {
     onNextButtonClick: () => void;
     onPreviousButtonClick: () => void;
     submitButtonText?: string;
+    isSubmitting?: boolean;
 }
 
 const WizardStep: FunctionComponent<WizardStepProps> = ({
@@ -40,6 +41,7 @@ const WizardStep: FunctionComponent<WizardStepProps> = ({
     onNextButtonClick,
     onPreviousButtonClick,
     submitButtonText,
+    isSubmitting,
 }) => {
     const [showError, setShowError] = useState(false);
     const formOptions = useFormApi();
@@ -84,6 +86,7 @@ const WizardStep: FunctionComponent<WizardStepProps> = ({
                 formOptions.handleSubmit();
             }}
             disableStepNavigation={true}
+            isLoadingNextStep={isSubmitting}
         />
     );
 };

--- a/src/components/FormRenderer/components/Wizard/index.tsx
+++ b/src/components/FormRenderer/components/Wizard/index.tsx
@@ -17,6 +17,7 @@ import React, { FunctionComponent, useMemo, useState } from 'react';
 import { Field } from '@data-driven-forms/react-form-renderer';
 import { WizardStepInfo } from '../../../Wizard';
 import WizardStep from './components/WizardStep';
+import { useFormRendererContext } from '../../index';
 
 export interface WizardMappingProps {
     fields: Field[];
@@ -26,6 +27,7 @@ export interface WizardMappingProps {
 const WizardMapping: FunctionComponent<WizardMappingProps> = (props) => {
     const [maxStepIndex, setMaxStepIndex] = useState(0);
     const [activeStepIndex, setActiveStepIndex] = useState(0);
+    const { isSubmitting } = useFormRendererContext();
 
     const handleNextButtonClick = () => {
         const target = activeStepIndex + 1;
@@ -64,6 +66,7 @@ const WizardMapping: FunctionComponent<WizardMappingProps> = (props) => {
             submitButtonText={props.submitButtonText}
             onNextButtonClick={handleNextButtonClick}
             onPreviousButtonClick={handlePreviousButtonClick}
+            isSubmitting={isSubmitting}
         />
     );
 };

--- a/src/components/FormRenderer/index.test.tsx
+++ b/src/components/FormRenderer/index.test.tsx
@@ -96,6 +96,33 @@ describe('FormRenderer', () => {
             expect(queryByRole('progressbar')).toBeInTheDocument();
         });
 
+        it('should show a loading spinner while submitting a wizard', () => {
+            const { queryByRole } = render(
+                <FormRenderer
+                    schema={{
+                        ...baseSchema,
+                        fields: [
+                            {
+                                component: componentTypes.WIZARD,
+                                name: 'wizard',
+                                fields: [
+                                    {
+                                        name: 'step-1',
+                                        fields: schema.fields,
+                                    },
+                                ],
+                            },
+                        ],
+                    }}
+                    onSubmit={handleSubmit}
+                    onCancel={handleCancel}
+                    isSubmitting={true}
+                />
+            );
+
+            expect(queryByRole('progressbar')).toBeInTheDocument();
+        });
+
         it('should not show a loading spinner by default', () => {
             const { queryByRole } = render(
                 <FormRenderer schema={schema} onSubmit={handleSubmit} onCancel={handleCancel} />

--- a/src/components/FormRenderer/index.tsx
+++ b/src/components/FormRenderer/index.tsx
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.                                                                              *
  ******************************************************************************************************************** */
-import React, { FunctionComponent, ElementType, useMemo } from 'react';
+import React, { FunctionComponent, ElementType, useContext } from 'react';
 import {
     FormRenderer as ReactFormRenderer,
     FormRendererProps as ReactFormRendererProps,
@@ -22,7 +22,7 @@ import { FormSubscription as ReactFormSubscription } from 'final-form';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
 import { ValidatorMapper } from '@data-driven-forms/react-form-renderer/validator-mapper';
 import FormTemplate from './components/FormTemplate';
-import { componentTypes, Schema, RenderProps } from './types';
+import { componentTypes, Schema } from './types';
 import basicComponentMapper from './basicComponenntMapper';
 
 export interface FormRendererProps {
@@ -46,6 +46,12 @@ export interface FormRendererProps {
     validatorMapper?: ValidatorMapper;
 }
 
+export interface FormRendererContextProps {
+    isSubmitting?: boolean;
+}
+const FormRendererContext = React.createContext<FormRendererContextProps>({});
+export const useFormRendererContext = () => useContext(FormRendererContext);
+
 /**
  * FormRenderer converts JSON form definitions into fully functional React forms.
  *
@@ -61,22 +67,19 @@ const FormRenderer: FunctionComponent<FormRendererProps> = ({
     subscription,
     customComponentWrapper,
 }) => {
-    const WrappedFormTemplate = useMemo(
-        () => (props: RenderProps) => <FormTemplate isSubmitting={isSubmitting} {...props} />,
-        [isSubmitting]
-    );
-
     return (
-        <ReactFormRenderer
-            componentMapper={{ ...basicComponentMapper, ...customComponentWrapper }}
-            FormTemplate={WrappedFormTemplate}
-            validatorMapper={validatorMapper}
-            schema={schema}
-            onSubmit={onSubmit}
-            onCancel={onCancel}
-            subscription={subscription}
-            initialValues={initialValues}
-        />
+        <FormRendererContext.Provider value={{ isSubmitting }}>
+            <ReactFormRenderer
+                componentMapper={{ ...basicComponentMapper, ...customComponentWrapper }}
+                FormTemplate={FormTemplate}
+                validatorMapper={validatorMapper}
+                schema={schema}
+                onSubmit={onSubmit}
+                onCancel={onCancel}
+                subscription={subscription}
+                initialValues={initialValues}
+            />
+        </FormRendererContext.Provider>
     );
 };
 export default FormRenderer;

--- a/src/components/Wizard/components/WizardInner/index.tsx
+++ b/src/components/Wizard/components/WizardInner/index.tsx
@@ -68,11 +68,11 @@ const WizardInner: FunctionComponent<WizardInnerProps> = ({
     const actions = useMemo(() => {
         return (
             <Inline>
-                <Button variant="link" onClick={onCancelButtonClick}>
+                <Button variant="link" onClick={onCancelButtonClick} disabled={isLoadingNextStep}>
                     {cancelButtonText}
                 </Button>
                 {activeStepIndex !== 0 && (
-                    <Button variant="normal" onClick={onPreviousButtonClick}>
+                    <Button variant="normal" onClick={onPreviousButtonClick} disabled={isLoadingNextStep}>
                         {previousButtonText}
                     </Button>
                 )}


### PR DESCRIPTION
The `Wizard` component doesn't use the `FormTemplate`, and so wasn't displaying a button with a
loading spinner when `isSubmitting` was true.

We use context to track whether or not the form is submitting, which means we don't re-render the
entire form every time `isSubmitting` is changed, which means the wizard doesn't "reset" to the
first step which was a pretty horrible user experience!


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
