### PR TITLE
feat(AppLayout): Add Split Panel drawer support

### DIFF
--- a/src/layouts/AppLayout/AppLayout.md
+++ b/src/layouts/AppLayout/AppLayout.md
@@ -1,3 +1,4 @@
+
 ### Open/Close Help Panel
 
 You can invoke the openHelpPanel method available from the AppLayoutContext from your component (must be descendants of AppLayout component) to trigger open of the help panel programmatically. 
@@ -56,6 +57,8 @@ import AppLayout, { Notification, useAppLayoutContext } from 'aws-northstar/layo
 import Box from 'aws-northstar/layouts/Box';
 import Header from 'aws-northstar/components/Header';
 import SideNavigation, { SideNavigationItemType } from 'aws-northstar/components/SideNavigation';
+import ColumnLayout, { Column } from 'aws-northstar/layouts/ColumnLayout';
+import KeyValuePair from 'aws-northstar/components/KeyValuePair';
 import Badge from 'aws-northstar/components/Badge';
 import BreadcrumbGroup from 'aws-northstar/components/BreadcrumbGroup';
 import HelpPanel from 'aws-northstar/components/HelpPanel';
@@ -108,6 +111,28 @@ const helpPanel = (
         <Heading variant="h5">h5 section header</Heading>
     </HelpPanel>
 );
+const splitPanel = (<ColumnLayout>
+    <Column key="column1">
+        <Stack>
+            <KeyValuePair label="Distribution Id" value="SLCCSMWOHOFUY0"></KeyValuePair>
+            <KeyValuePair label="Domain name" value="bbb.cloudfront.net"></KeyValuePair>
+        </Stack>
+    </Column>
+    <Column key="column2">
+        <Stack>
+            <KeyValuePair label="Price class" value="Use only US, Canada, Europe, and Asia"></KeyValuePair>
+            <KeyValuePair label="CNAMEs"></KeyValuePair>
+        </Stack>
+    </Column>
+    <Column key="column3">
+        <Stack>
+            <KeyValuePair label="SSL certificate" value="Default CloudFront SSL certificate"></KeyValuePair>
+            <KeyValuePair label="Custom SSL client support"></KeyValuePair>
+            <KeyValuePair label="Logging" value="Off"></KeyValuePair>
+        </Stack>
+    </Column>
+</ColumnLayout>);
+
 const breadcrumbGroup = (
     <BreadcrumbGroup
         items={[
@@ -158,8 +183,9 @@ const defaultNotifications = [
 
 const MainContent = () => {
     const { openHelpPanel, 
+        openSplitPanel,
         addNotification, 
-        dismissNotifications  } = useAppLayoutContext();
+        dismissNotifications } = useAppLayoutContext();
     
     const [ notificationId, setNotificationId ] = useState();
     
@@ -182,11 +208,15 @@ const MainContent = () => {
         dismissNotifications();
     }, [dismissNotifications]);
 
-    return (<Box bgcolor="grey.300" width="100%" height="1000px">
+    return (<Box bgcolor="grey.300" width="100%" height="800px">
             <Stack>
                 Main Content
                 <Button onClick={() => openHelpPanel()}>Open Help Panel</Button>
                 <Button onClick={() => openHelpPanel(false)}>Close Help Panel</Button>
+                 <Button onClick={() => {
+                     openSplitPanel();
+                }}>Open Split Panel</Button>
+                <Button onClick={() => openSplitPanel(false)}>Close Split Panel</Button>
                 <Button onClick={handleAddClick}>Add New Notification</Button>
                 <Button onClick={handleRemoveLastClick}>Remove Last Added Notification</Button>
                 <Button onClick={handleRemoveAll}>Remove All notifications</Button>
@@ -205,6 +235,7 @@ const handleDismiss = (id) => {
         header={header}
         navigation={navigation}
         helpPanel={helpPanel}
+        splitPanel={splitPanel}
         breadcrumbs={breadcrumbGroup}
         notifications={notifications.map(n => ({ ...n, onDismiss: () => handleDismiss(n.id) }))}
     >

--- a/src/layouts/AppLayout/components/Sidebar/index.tsx
+++ b/src/layouts/AppLayout/components/Sidebar/index.tsx
@@ -20,9 +20,6 @@ import Close from '@material-ui/icons/Close';
 import IconButton from '@material-ui/core/IconButton';
 
 const useStyles = makeStyles<Theme, SidebarProps>((theme) => ({
-    hide: {
-        display: 'none',
-    },
     drawer: {
         height: '100%',
         flexShrink: 0,
@@ -59,14 +56,11 @@ const useStyles = makeStyles<Theme, SidebarProps>((theme) => ({
         },
     },
     sidebar: {
-        display: 'none',
-        [theme.breakpoints.up('sm')]: {
-            display: 'flex',
-            borderRadius: 0,
-            backgroundColor: theme.palette.background.paper,
-            borderRight: `1px solid ${theme.palette.grey['200']}`,
-            minWidth: '50px',
-        },
+        display: 'flex',
+        borderRadius: 0,
+        backgroundColor: theme.palette.background.paper,
+        borderRight: `1px solid ${theme.palette.grey['200']}`,
+        minWidth: '50px',
     },
 }));
 
@@ -78,6 +72,7 @@ export enum SidebarType {
 export interface SidebarProps {
     sidebarWidth: number;
     isSidebarOpen: string;
+    displayIcon: boolean;
     setIsSidebarOpen: (open: string) => void;
     type: SidebarType;
     renderIcon: (rootClasses: string) => ReactNode;
@@ -96,7 +91,10 @@ const Sidebar: FunctionComponent<SidebarProps> = (props) => {
 
     return (
         <>
-            {props.type === SidebarType.SIDE_NAVIGATION && !isOpen && props.renderIcon(classes.sidebar)}
+            {props.displayIcon &&
+                props.type === SidebarType.SIDE_NAVIGATION &&
+                !isOpen &&
+                props.renderIcon(classes.sidebar)}
             <Drawer
                 className={classes.drawer}
                 variant="persistent"
@@ -116,7 +114,7 @@ const Sidebar: FunctionComponent<SidebarProps> = (props) => {
                 </div>
                 {props.children}
             </Drawer>
-            {props.type === SidebarType.HELP_PANEL && !isOpen && props.renderIcon(classes.sidebar)}
+            {props.displayIcon && props.type === SidebarType.HELP_PANEL && !isOpen && props.renderIcon(classes.sidebar)}
         </>
     );
 };

--- a/src/layouts/AppLayout/components/SplitPanel/index.test.tsx
+++ b/src/layouts/AppLayout/components/SplitPanel/index.test.tsx
@@ -1,0 +1,99 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+import React from 'react';
+import { render, cleanup, fireEvent, act } from '@testing-library/react';
+import SplitPanel from '.';
+
+const mockSetIsSplitPanelOpen = jest.fn();
+
+describe('SplitPanel', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        cleanup();
+    });
+
+    it('renders the Split Panel', () => {
+        const { getByText, getByTestId } = render(
+            <SplitPanel fullMode isSplitPanelOpen={true} setIsSplitPanelOpen={mockSetIsSplitPanelOpen}>
+                SplitPanel
+            </SplitPanel>
+        );
+
+        expect(getByText('SplitPanel')).toBeVisible();
+        expect(getByTestId('close-split-panel')).toBeVisible();
+        expect(getByTestId('toggle-expand-split-panel')).toBeVisible();
+        expect(getByTestId('resize-split-panel')).toBeVisible();
+    });
+
+    it('renders the Split Panel in mobile view', () => {
+        const { getByText, getByTestId, queryByTestId } = render(
+            <SplitPanel fullMode={false} isSplitPanelOpen={true} setIsSplitPanelOpen={mockSetIsSplitPanelOpen}>
+                SplitPanel
+            </SplitPanel>
+        );
+
+        expect(getByText('SplitPanel')).toBeVisible();
+        expect(getByTestId('close-split-panel')).toBeVisible();
+        expect(queryByTestId('toggle-expand-split-panel')).toBeNull();
+        expect(queryByTestId('resize-split-panel')).toBeNull();
+    });
+
+    it('should not render the Split Panel node when the isSplitPanelOpen is false', () => {
+        const { queryByText } = render(
+            <SplitPanel fullMode isSplitPanelOpen={false} setIsSplitPanelOpen={mockSetIsSplitPanelOpen}>
+                SplitPanel
+            </SplitPanel>
+        );
+
+        expect(queryByText('SplitPanel')).toBeNull();
+    });
+
+    it('should toggle the split panel when users click the FullscreenExit/Fullscreen button', () => {
+        const { getByText, getByTestId, queryByText } = render(
+            <SplitPanel fullMode isSplitPanelOpen={true} setIsSplitPanelOpen={mockSetIsSplitPanelOpen}>
+                SplitPanel
+            </SplitPanel>
+        );
+
+        expect(getByText('SplitPanel')).toBeVisible();
+
+        act(() => {
+            fireEvent.click(getByTestId('toggle-expand-split-panel'));
+        });
+
+        expect(queryByText('SplitPanel')).toBeNull();
+
+        act(() => {
+            fireEvent.click(getByTestId('toggle-expand-split-panel'));
+        });
+
+        expect(getByText('SplitPanel')).toBeVisible();
+    });
+
+    it('should trigger the setIsSplitPanelOpen when users click the close button', () => {
+        const { getByTestId } = render(
+            <SplitPanel fullMode isSplitPanelOpen={true} setIsSplitPanelOpen={mockSetIsSplitPanelOpen}>
+                SplitPanel
+            </SplitPanel>
+        );
+
+        act(() => {
+            fireEvent.click(getByTestId('close-split-panel'));
+        });
+
+        expect(mockSetIsSplitPanelOpen).toHaveBeenCalledWith(false);
+    });
+});

--- a/src/layouts/AppLayout/components/SplitPanel/index.tsx
+++ b/src/layouts/AppLayout/components/SplitPanel/index.tsx
@@ -153,7 +153,11 @@ const SplitPanel: FunctionComponent<SplitPanelProps> = ({
                 {fullMode && (
                     <Box display="flex" justifyContent="center" width="100%">
                         {!minimized && (
-                            <IconButton onMouseDown={handleMouseDown} className={styles.dragHandle}>
+                            <IconButton
+                                data-testid="resize-split-panel"
+                                onMouseDown={handleMouseDown}
+                                className={styles.dragHandle}
+                            >
                                 <DragHandle />
                             </IconButton>
                         )}
@@ -161,17 +165,17 @@ const SplitPanel: FunctionComponent<SplitPanelProps> = ({
                 )}
                 <Box className={styles.control}>
                     {fullMode && (
-                        <IconButton onClick={handleToggleResize}>
+                        <IconButton data-testid="toggle-expand-split-panel" onClick={handleToggleResize}>
                             {minimized ? <Fullscreen /> : <FullscreenExit />}
                         </IconButton>
                     )}
-                    <IconButton onClick={handleDrawerClose}>
+                    <IconButton data-testid="close-split-panel" onClick={handleDrawerClose}>
                         <Close />
                     </IconButton>
                 </Box>
             </Box>
             {!minimized && (
-                <Box p={1} overflow="auto" className={styles.content}>
+                <Box p={1} overflow="auto" className={styles.content} data-testid="content">
                     {children}
                 </Box>
             )}

--- a/src/layouts/AppLayout/components/SplitPanel/index.tsx
+++ b/src/layouts/AppLayout/components/SplitPanel/index.tsx
@@ -1,0 +1,182 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+import React, { MouseEvent, FunctionComponent, useState, useCallback, useRef, useEffect } from 'react';
+import Drawer from '@material-ui/core/Drawer';
+import Close from '@material-ui/icons/Close';
+import FullscreenExit from '@material-ui/icons/FullscreenExit';
+import Fullscreen from '@material-ui/icons/Fullscreen';
+import DragHandle from '@material-ui/icons/DragHandle';
+import IconButton from '@material-ui/core/IconButton';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+import Box from '../../../Box';
+
+const useStyles = makeStyles<
+    Theme,
+    {
+        height: number;
+    }
+>((theme) => ({
+    drawerPaper: {
+        [theme.breakpoints.up('sm')]: {
+            position: 'relative',
+            width: '100%',
+        },
+        [theme.breakpoints.down('xs')]: {
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            width: '100%',
+            zIndex: theme.zIndex.modal + 10,
+        },
+    },
+    content: ({ height }) => ({
+        height,
+    }),
+    dragHandle: {
+        padding: 0,
+        margin: 0,
+        cursor: 'row-resize',
+    },
+    control: {
+        position: 'absolute',
+        right: 0,
+        top: '5px',
+        zIndex: 1,
+        '& > button': {
+            padding: 0,
+            marginRight: '5px',
+        },
+        '& > button > span': {
+            padding: 0,
+            display: 'inline',
+            lineHeight: 1.5,
+        },
+    },
+    controlBar: {
+        position: 'relative',
+        display: 'flex',
+        borderRadius: 0,
+        backgroundColor: theme.palette.background.paper,
+        borderTop: `1px solid ${theme.palette.grey['200']}`,
+        minHeight: '40px',
+    },
+}));
+
+export interface SplitPanelProps {
+    defaultSplitPanelHeight?: number;
+    isSplitPanelOpen: boolean;
+    fullMode: boolean;
+    setIsSplitPanelOpen: (open: boolean) => void;
+}
+
+const SplitPanel: FunctionComponent<SplitPanelProps> = ({
+    children,
+    defaultSplitPanelHeight = 300,
+    isSplitPanelOpen,
+    setIsSplitPanelOpen,
+    fullMode,
+}) => {
+    const [height, setHeight] = useState(defaultSplitPanelHeight);
+    const mouseMoveListener = useRef<any | null>();
+    const mouseUpListener = useRef<any>();
+    const styles = useStyles({
+        height,
+    });
+    useEffect(() => {
+        setHeight(defaultSplitPanelHeight);
+    }, [defaultSplitPanelHeight]);
+
+    const [minimized, setMinimized] = useState(false);
+    const handleDrawerClose = useCallback(() => {
+        setIsSplitPanelOpen(false);
+    }, [setIsSplitPanelOpen]);
+
+    const handleToggleResize = useCallback(() => {
+        setMinimized((currentValue) => !currentValue);
+    }, []);
+
+    const handleMouseDown = useCallback(() => {
+        const handleMouseMove = (e: MouseEvent) => {
+            const offsetBottom = document.body.offsetHeight - (e.clientY - document.body.offsetTop);
+            let minHeight = 50;
+            let maxHeight = document.body.offsetHeight * 0.5;
+            if (offsetBottom > minHeight && offsetBottom < maxHeight) {
+                setHeight(offsetBottom - 50);
+            }
+        };
+
+        const handleMouseUp = () => {
+            if (mouseMoveListener.current) {
+                document.removeEventListener('mousemove', mouseMoveListener.current);
+                mouseMoveListener.current = null;
+            }
+            if (mouseUpListener.current) {
+                document.removeEventListener('mouseup', mouseUpListener.current);
+                mouseUpListener.current = null;
+            }
+        };
+
+        mouseUpListener.current = handleMouseUp;
+        document.addEventListener('mouseup', mouseUpListener.current);
+        mouseMoveListener.current = handleMouseMove;
+        document.addEventListener('mousemove', mouseMoveListener.current);
+    }, [setHeight]);
+
+    return isSplitPanelOpen ? (
+        <Drawer
+            variant="persistent"
+            anchor="bottom"
+            open={isSplitPanelOpen}
+            classes={{
+                paper: styles.drawerPaper,
+            }}
+            SlideProps={{
+                timeout: 0,
+            }}
+        >
+            <Box className={styles.controlBar}>
+                {fullMode && (
+                    <Box display="flex" justifyContent="center" width="100%">
+                        {!minimized && (
+                            <IconButton onMouseDown={handleMouseDown} className={styles.dragHandle}>
+                                <DragHandle />
+                            </IconButton>
+                        )}
+                    </Box>
+                )}
+                <Box className={styles.control}>
+                    {fullMode && (
+                        <IconButton onClick={handleToggleResize}>
+                            {minimized ? <Fullscreen /> : <FullscreenExit />}
+                        </IconButton>
+                    )}
+                    <IconButton onClick={handleDrawerClose}>
+                        <Close />
+                    </IconButton>
+                </Box>
+            </Box>
+            {!minimized && (
+                <Box p={1} overflow="auto" className={styles.content}>
+                    {children}
+                </Box>
+            )}
+        </Drawer>
+    ) : null;
+};
+
+export default SplitPanel;

--- a/src/layouts/AppLayout/index.stories.tsx
+++ b/src/layouts/AppLayout/index.stories.tsx
@@ -17,6 +17,8 @@ import React, { FunctionComponent, useCallback, useEffect, useState } from 'reac
 import { action } from '@storybook/addon-actions';
 import { v4 as uuidv4 } from 'uuid';
 import AppLayout, { Notification, useAppLayoutContext } from '.';
+import ColumnLayout, { Column } from '../ColumnLayout';
+import KeyValuePair from '../../components/KeyValuePair';
 import Badge from '../../components/Badge';
 import Box from '../Box';
 import BreadcrumbGroup from '../../components/BreadcrumbGroup';
@@ -79,6 +81,7 @@ const helpPanel = (
         <Heading variant="h5">h5 section header</Heading>
     </HelpPanel>
 );
+
 const breadcrumbGroup = (
     <BreadcrumbGroup
         items={[
@@ -101,6 +104,31 @@ const breadcrumbGroup = (
         ]}
     />
 );
+
+const splitPanel = (
+    <ColumnLayout>
+        <Column key="column1">
+            <Stack>
+                <KeyValuePair label="Distribution Id" value="SLCCSMWOHOFUY0"></KeyValuePair>
+                <KeyValuePair label="Domain name" value="bbb.cloudfront.net"></KeyValuePair>
+            </Stack>
+        </Column>
+        <Column key="column2">
+            <Stack>
+                <KeyValuePair label="Price class" value="Use only US, Canada, Europe, and Asia"></KeyValuePair>
+                <KeyValuePair label="CNAMEs"></KeyValuePair>
+            </Stack>
+        </Column>
+        <Column key="column3">
+            <Stack>
+                <KeyValuePair label="SSL certificate" value="Default CloudFront SSL certificate"></KeyValuePair>
+                <KeyValuePair label="Custom SSL client support"></KeyValuePair>
+                <KeyValuePair label="Logging" value="Off"></KeyValuePair>
+            </Stack>
+        </Column>
+    </ColumnLayout>
+);
+
 const defaultNotifications: Notification[] = [
     {
         id: '1',
@@ -140,12 +168,31 @@ export const Default = () => {
             navigation={navigation}
             helpPanel={helpPanel}
             breadcrumbs={breadcrumbGroup}
+            splitPanel={splitPanel}
             notifications={notifications.map((n) => ({ ...n, onDismiss: () => handleDismiss(n.id) }))}
         >
             <Stack>
-                <GeneralInfo />
                 <SimpleTable />
             </Stack>
+        </AppLayout>
+    );
+};
+
+const DynamicSplitPanelSubComponent: React.FunctionComponent<any> = ({ children }) => {
+    const { setSplitPanelContent, openSplitPanel } = useAppLayoutContext();
+
+    const handleButtonClick = useCallback(() => {
+        setSplitPanelContent(splitPanel);
+        openSplitPanel(true);
+    }, [openSplitPanel, setSplitPanelContent]);
+
+    return <Button onClick={handleButtonClick}>Show Details</Button>;
+};
+
+export const DynamicSplitPanel = () => {
+    return (
+        <AppLayout header={header} breadcrumbs={breadcrumbGroup}>
+            <DynamicSplitPanelSubComponent />
         </AppLayout>
     );
 };

--- a/src/layouts/AppLayout/index.stories.tsx
+++ b/src/layouts/AppLayout/index.stories.tsx
@@ -178,7 +178,7 @@ export const Default = () => {
     );
 };
 
-const DynamicSplitPanelSubComponent: React.FunctionComponent<any> = ({ children }) => {
+const DynamicSplitPanelSubComponent: React.FunctionComponent<any> = () => {
     const { setSplitPanelContent, openSplitPanel } = useAppLayoutContext();
 
     const handleButtonClick = useCallback(() => {

--- a/src/layouts/AppLayout/index.test.tsx
+++ b/src/layouts/AppLayout/index.test.tsx
@@ -14,15 +14,16 @@
   limitations under the License.                                                                              *
  ******************************************************************************************************************** */
 import React from 'react';
-import { render, cleanup, fireEvent, act } from '@testing-library/react';
+import { render, cleanup, fireEvent, act, waitFor } from '@testing-library/react';
 import Header from '../../components/Header';
 import AppLayout, { useAppLayoutContext, Notification } from '.';
+import useLocalStorage from 'react-use-localstorage';
 
 const mockSetLocalStorage = jest.fn();
 
 jest.mock('react-use-localstorage', () => ({
     __esModule: true,
-    default: () => ['false', mockSetLocalStorage],
+    default: jest.fn(),
 }));
 
 jest.mock('@material-ui/core/styles/makeStyles', () => ({
@@ -34,7 +35,9 @@ const header = <Header title="App Title" />;
 
 const navigation = <div>App Name</div>;
 
-const helpPanel = <div>Help</div>;
+const helpPanel = <div>HelpPanel</div>;
+
+const splitPanel = <div>SplitPanel</div>;
 
 const breadcrumbsNode = <div>MockBreadcrumbs</div>;
 
@@ -52,6 +55,11 @@ const notifications: Notification[] = [
 ];
 
 describe('AppLayout', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+        (useLocalStorage as jest.Mock).mockReturnValue(['false', mockSetLocalStorage]);
+    });
+
     afterEach(cleanup);
 
     it('renders the headers', () => {
@@ -67,20 +75,31 @@ describe('AppLayout', () => {
     });
 
     describe('NavSideBar', () => {
-        it('renders the nav sidebar node hide', () => {
+        it('renders the nav sidebar node but no visible', () => {
             const { getByText } = render(<AppLayout header={header} navigation={navigation} />);
 
             expect(getByText('App Name')).toBeInTheDocument();
             expect(getByText('App Name')).not.toBeVisible();
         });
 
-        it('should open the nav sidebar drawer when users click the button', () => {
-            const { getAllByTestId } = render(<AppLayout header={header} navigation={navigation} />);
+        it('should set the local storage value true when users click the open nav drawer button', () => {
+            const { getByTestId } = render(<AppLayout header={header} navigation={navigation} />);
             act(() => {
-                fireEvent.click(getAllByTestId('open-nav-drawer')[1]);
+                fireEvent.click(getByTestId('open-nav-drawer'));
             });
 
             expect(mockSetLocalStorage).toBeCalledWith('true');
+        });
+
+        it('should render the nav sidebar drawer visible when local storage returns true', () => {
+            (useLocalStorage as jest.Mock).mockReturnValue(['true', mockSetLocalStorage]);
+
+            const { getByTestId, getByText } = render(<AppLayout header={header} navigation={navigation} />);
+            act(() => {
+                fireEvent.click(getByTestId('open-nav-drawer'));
+            });
+
+            expect(getByText('App Name')).toBeVisible();
         });
     });
 
@@ -88,17 +107,29 @@ describe('AppLayout', () => {
         it('renders the help panel node', () => {
             const { getByText } = render(<AppLayout header={header} helpPanel={helpPanel} />);
 
-            expect(getByText('Help')).toBeInTheDocument();
-            expect(getByText('Help')).not.toBeVisible();
+            expect(getByText('HelpPanel')).toBeInTheDocument();
+            expect(getByText('HelpPanel')).not.toBeVisible();
         });
 
-        it('should open the help panel drawer when users click the button', () => {
-            const { getAllByTestId } = render(<AppLayout header={header} navigation={navigation} />);
+        it('should set the local storage value true when users click the button', () => {
+            const { getByTestId } = render(<AppLayout header={header} helpPanel={helpPanel} />);
+
             act(() => {
-                fireEvent.click(getAllByTestId('open-nav-drawer')[1]);
+                fireEvent.click(getByTestId('open-helppanel-drawer'));
             });
 
             expect(mockSetLocalStorage).toBeCalledWith('true');
+        });
+
+        it('should render the help panel drawer visible when local storage returns true', () => {
+            (useLocalStorage as jest.Mock).mockReturnValue(['true', mockSetLocalStorage]);
+
+            const { getByTestId, getByText } = render(<AppLayout header={header} helpPanel={helpPanel} />);
+            act(() => {
+                fireEvent.click(getByTestId('open-helppanel-drawer'));
+            });
+
+            expect(getByText('HelpPanel')).toBeVisible();
         });
 
         it('should trigger open help panel when users call openHelpPanel helper method', () => {
@@ -111,10 +142,11 @@ describe('AppLayout', () => {
                 );
             };
             const { getByTestId } = render(
-                <AppLayout header={header} navigation={navigation}>
+                <AppLayout header={header} helpPanel={helpPanel}>
                     <ContentNode />
                 </AppLayout>
             );
+
             act(() => {
                 fireEvent.click(getByTestId('trigger-open'));
             });
@@ -132,10 +164,11 @@ describe('AppLayout', () => {
                 );
             };
             const { getByTestId } = render(
-                <AppLayout header={header} navigation={navigation}>
+                <AppLayout header={header} helpPanel={helpPanel}>
                     <ContentNode />
                 </AppLayout>
             );
+
             act(() => {
                 fireEvent.click(getByTestId('trigger-close'));
             });
@@ -158,15 +191,54 @@ describe('AppLayout', () => {
                 );
             };
             const { getByTestId, getByText } = render(
-                <AppLayout header={header} navigation={navigation}>
+                <AppLayout header={header} helpPanel={helpPanel}>
                     <ContentNode />
                 </AppLayout>
             );
+
             act(() => {
                 fireEvent.click(getByTestId('trigger-update'));
             });
 
             expect(getByText(dynamicContent)).toBeInTheDocument();
+        });
+    });
+
+    describe('SplitPanel', () => {
+        it('renders the Split Panel node', () => {
+            const { getByText } = render(<AppLayout header={header} splitPanel={splitPanel} />);
+
+            expect(getByText('SplitPanel')).toBeVisible();
+        });
+
+        it('should trigger open split panel when users call openSplitPanel helper method', () => {
+            const ContentNode = () => {
+                const { openSplitPanel, setSplitPanelContent } = useAppLayoutContext();
+                return (
+                    <div>
+                        <button
+                            data-testid="trigger-open"
+                            onClick={() => {
+                                setSplitPanelContent(splitPanel);
+                                openSplitPanel();
+                            }}
+                        />
+                    </div>
+                );
+            };
+            const { getByTestId, queryByText, getByText } = render(
+                <AppLayout header={header}>
+                    <ContentNode />
+                </AppLayout>
+            );
+
+            expect(queryByText('SplitPanel')).toBeNull();
+
+            act(() => {
+                fireEvent.click(getByTestId('trigger-open'));
+            });
+
+            expect(getByText('SplitPanel')).toBeVisible();
         });
     });
 
@@ -177,7 +249,7 @@ describe('AppLayout', () => {
             expect(getByText('Failed to update 1 order')).toBeVisible();
         });
 
-        it('renders dynamically added notifications', () => {
+        it('renders dynamically added notifications', async () => {
             const notification: Notification = {
                 id: '1',
                 type: 'success',
@@ -202,7 +274,9 @@ describe('AppLayout', () => {
                 fireEvent.click(getByTestId('trigger-add-notification'));
             });
 
-            expect(getByText('Your request 1 is being processed')).toBeVisible();
+            waitFor(() => {
+                expect(getByText('Your request 1 is being processed')).toBeVisible();
+            });
 
             act(() => {
                 fireEvent.click(getByLabelText('Close'));

--- a/src/layouts/AppLayout/index.test.tsx
+++ b/src/layouts/AppLayout/index.test.tsx
@@ -240,6 +240,33 @@ describe('AppLayout', () => {
 
             expect(getByText('SplitPanel')).toBeVisible();
         });
+
+        it('should close split panel when users call openSplitPanel with false', () => {
+            const ContentNode = () => {
+                const { openSplitPanel } = useAppLayoutContext();
+                return (
+                    <div>
+                        <button
+                            data-testid="trigger-close"
+                            onClick={() => {
+                                openSplitPanel(false);
+                            }}
+                        />
+                    </div>
+                );
+            };
+            const { getByTestId, queryByText } = render(
+                <AppLayout header={header} splitPanel={splitPanel}>
+                    <ContentNode />
+                </AppLayout>
+            );
+
+            act(() => {
+                fireEvent.click(getByTestId('trigger-close'));
+            });
+
+            expect(queryByText('SplitPanel')).toBeNull();
+        });
     });
 
     describe('Notifications', () => {

--- a/src/layouts/AppLayout/index.test.tsx
+++ b/src/layouts/AppLayout/index.test.tsx
@@ -14,7 +14,7 @@
   limitations under the License.                                                                              *
  ******************************************************************************************************************** */
 import React from 'react';
-import { render, cleanup, fireEvent, act, waitFor } from '@testing-library/react';
+import { render, cleanup, fireEvent, act } from '@testing-library/react';
 import Header from '../../components/Header';
 import AppLayout, { useAppLayoutContext, Notification } from '.';
 import useLocalStorage from 'react-use-localstorage';
@@ -249,7 +249,7 @@ describe('AppLayout', () => {
             expect(getByText('Failed to update 1 order')).toBeVisible();
         });
 
-        it('renders dynamically added notifications', async () => {
+        it('renders dynamically added notifications', () => {
             const notification: Notification = {
                 id: '1',
                 type: 'success',
@@ -274,9 +274,7 @@ describe('AppLayout', () => {
                 fireEvent.click(getByTestId('trigger-add-notification'));
             });
 
-            waitFor(() => {
-                expect(getByText('Your request 1 is being processed')).toBeVisible();
-            });
+            expect(getByText('Your request 1 is being processed')).toBeVisible();
 
             act(() => {
                 fireEvent.click(getByLabelText('Close'));

--- a/src/layouts/GetStarted/index.tsx
+++ b/src/layouts/GetStarted/index.tsx
@@ -106,23 +106,25 @@ const GetStarted: FunctionComponent<GetStartedProps> = ({
     return (
         <Grid container className={styles.root}>
             <Grid item xs={12} className={styles.headerRow}>
-                <Grid container justify="center" ref={headerRef}>
-                    <Grid item xs={10} lg={8} className={styles.header}>
-                        <Text>{category}</Text>
+                <div ref={headerRef}>
+                    <Grid container justify="center">
+                        <Grid item xs={10} lg={8} className={styles.header}>
+                            <Text>{category}</Text>
+                        </Grid>
+                        <Grid item xs={10} sm={6} lg={5} xl={6} className={styles.header}>
+                            <Stack>
+                                <Typography variant="h1" className={styles.title}>
+                                    {title}
+                                </Typography>
+                                <Typography className={styles.subTitle}>{subTitle}</Typography>
+                                <Text>{description}</Text>
+                            </Stack>
+                        </Grid>
+                        <Grid item xs={10} sm={4} lg={3} xl={2} className={styles.action}>
+                            <div ref={actionRef}>{action}</div>
+                        </Grid>
                     </Grid>
-                    <Grid item xs={10} sm={6} lg={5} xl={6} className={styles.header}>
-                        <Stack>
-                            <Typography variant="h1" className={styles.title}>
-                                {title}
-                            </Typography>
-                            <Typography className={styles.subTitle}>{subTitle}</Typography>
-                            <Text>{description}</Text>
-                        </Stack>
-                    </Grid>
-                    <Grid item xs={10} sm={4} lg={3} xl={2} className={styles.action}>
-                        <div ref={actionRef}>{action}</div>
-                    </Grid>
-                </Grid>
+                </div>
             </Grid>
             <Grid item>
                 <Grid container justify="center">

--- a/src/layouts/Paper/index.test.tsx
+++ b/src/layouts/Paper/index.test.tsx
@@ -1,0 +1,31 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+import React from 'react';
+import { render } from '@testing-library/react';
+import Placeholder from '../../components/Placeholder';
+import Paper from '.';
+
+describe('Paper', () => {
+    it('should render the children', () => {
+        const { getAllByTestId } = render(
+            <Paper>
+                <Placeholder />
+            </Paper>
+        );
+
+        expect(getAllByTestId('placeholder')).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
*Description of changes:*

This PR is to add the Split Panel support to the AppLayout so that users can display detailed info in the same page. 

![Screen Shot 2021-09-24 at 1 05 23 PM](https://user-images.githubusercontent.com/5362048/134615049-622e862d-4e0e-4906-b7bf-5fe400e7a6ac.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
