### PR TITLE
refactor(SplitPanel): Reduce the box metrics usage to reduce browser reflow

### DIFF
--- a/src/layouts/AppLayout/components/SplitPanel/index.tsx
+++ b/src/layouts/AppLayout/components/SplitPanel/index.tsx
@@ -115,7 +115,7 @@ const SplitPanel: FunctionComponent<SplitPanelProps> = ({
             const { offsetHeight, offsetTop } = document.body;
             const offsetBottom = offsetHeight - (e.clientY - offsetTop);
             const minHeight = 50;
-            let maxHeight = offsetHeight * 0.5;
+            const maxHeight = offsetHeight * 0.5;
             if (offsetBottom > minHeight && offsetBottom < maxHeight) {
                 setHeight(offsetBottom - minHeight);
             }

--- a/src/layouts/AppLayout/components/SplitPanel/index.tsx
+++ b/src/layouts/AppLayout/components/SplitPanel/index.tsx
@@ -112,11 +112,12 @@ const SplitPanel: FunctionComponent<SplitPanelProps> = ({
 
     const handleMouseDown = useCallback(() => {
         const handleMouseMove = (e: MouseEvent) => {
-            const offsetBottom = document.body.offsetHeight - (e.clientY - document.body.offsetTop);
-            let minHeight = 50;
-            let maxHeight = document.body.offsetHeight * 0.5;
+            const { offsetHeight, offsetTop } = document.body;
+            const offsetBottom = offsetHeight - (e.clientY - offsetTop);
+            const minHeight = 50;
+            let maxHeight = offsetHeight * 0.5;
             if (offsetBottom > minHeight && offsetBottom < maxHeight) {
-                setHeight(offsetBottom - 50);
+                setHeight(offsetBottom - minHeight);
             }
         };
 

--- a/src/layouts/AppLayout/components/SplitPanel/index.tsx
+++ b/src/layouts/AppLayout/components/SplitPanel/index.tsx
@@ -92,8 +92,8 @@ const SplitPanel: FunctionComponent<SplitPanelProps> = ({
     fullMode,
 }) => {
     const [height, setHeight] = useState(defaultSplitPanelHeight);
-    const mouseMoveListener = useRef<any | null>();
-    const mouseUpListener = useRef<any>();
+    const mouseMoveListener = useRef<((args: any) => void) | null>();
+    const mouseUpListener = useRef<(() => void) | null>();
     const styles = useStyles({
         height,
     });


### PR DESCRIPTION
Just made some refactoring to reduce the usage of box metrics properties.

It will reduce browser layout reflows

https://gist.github.com/paulirish/5d52fb081b3570c81e3a

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
