### PR TITLE
feat(Table): Add support of onSelectedRowIdsChange to handle the event only when the row selection changes

### DIFF
--- a/src/components/FormRenderer/index.tsx
+++ b/src/components/FormRenderer/index.tsx
@@ -22,7 +22,7 @@ import { FormSubscription as ReactFormSubscription } from 'final-form';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
 import { ValidatorMapper } from '@data-driven-forms/react-form-renderer/validator-mapper';
 import FormTemplate from './components/FormTemplate';
-import { componentTypes, Schema } from './types';
+import { componentTypes, Schema, Option } from './types';
 import basicComponentMapper from './basicComponenntMapper';
 
 export interface FormRendererProps {
@@ -85,5 +85,5 @@ const FormRenderer: FunctionComponent<FormRendererProps> = ({
 export default FormRenderer;
 
 export { componentTypes, validatorTypes };
-export type { ValidatorMapper };
+export type { ValidatorMapper, Schema, Option };
 export type { Field } from '@data-driven-forms/react-form-renderer/common-types';

--- a/src/components/FormRendererTable/index.test.tsx
+++ b/src/components/FormRendererTable/index.test.tsx
@@ -98,50 +98,6 @@ describe('FormRendererTable', () => {
             expect(getAllByRole('checkbox')).toHaveLength(3);
         });
 
-        it('should render all the items in orginal data order by default', () => {
-            const { getAllByRole } = render(
-                <FormRenderer
-                    customComponentWrapper={customComponentMapping}
-                    schema={schema}
-                    onSubmit={handleSubmit}
-                    onCancel={handleCancel}
-                />
-            );
-
-            const ids = getAllByRole('checkbox')
-                .map((cb) => cb.id)
-                .slice(1);
-
-            expect(ids).toEqual(items.map((i) => i.id));
-        });
-
-        it('should render selected items first', () => {
-            const { getAllByRole } = render(
-                <FormRenderer
-                    customComponentWrapper={customComponentMapping}
-                    schema={schema}
-                    onSubmit={handleSubmit}
-                    onCancel={handleCancel}
-                    initialValues={{
-                        table: [
-                            {
-                                id: 'id2',
-                                name: 'Order 2',
-                                createdDate: '2019-11-12',
-                            },
-                        ],
-                    }}
-                />
-            );
-
-            const ids = getAllByRole('checkbox')
-                .map((cb) => cb.id)
-                .slice(1);
-
-            expect(ids[0]).toBe('id2');
-            expect(ids[1]).toBe('id1');
-        });
-
         it('should allow selection', () => {
             const { getAllByRole, getByText } = render(
                 <FormRenderer

--- a/src/components/FormRendererTable/index.test.tsx
+++ b/src/components/FormRendererTable/index.test.tsx
@@ -108,10 +108,12 @@ describe('FormRendererTable', () => {
                 />
             );
 
-            const id2 = getAllByRole('checkbox').filter((cb) => cb.id === 'id2')[0];
+            const id2 = getAllByRole('checkbox').find((cb) => cb.id === 'id2');
+
+            expect(id2).not.toBeUndefined();
 
             act(() => {
-                fireEvent.click(id2);
+                fireEvent.click(id2!);
             });
 
             expect(id2).toBeChecked();

--- a/src/components/FormRendererTable/index.tsx
+++ b/src/components/FormRendererTable/index.tsx
@@ -35,19 +35,41 @@ const TableMapping = (props: UseFieldApiConfig) => {
         getRowId,
         stretch,
         meta: { error, submitFailed },
+        sortBy: defaultSortBy,
         ...rest
     } = useFieldApi(props);
     const controlId = useUniqueId(input.name);
     const errorText = getErrorText(validateOnMount, submitFailed, showError, error);
-    const handleSelectionChange = useCallback(
-        (selectedItems) => {
+    const handleSelectedRowIdsChange = useCallback(
+        (selectedIds) => {
+            const selectedItems = items.filter((i: any[]) => {
+                const id = getRowId?.(i) || i['id'];
+                return id && selectedIds.includes(id);
+            });
             input.onChange(selectedItems);
         },
         [input]
     );
     const selectedRowIds = useMemo(() => {
-        return getRowId && input.value ? input.value.map(getRowId) : [];
+        return (input.value && getRowId && input.value.map(getRowId)) || [];
     }, [input.value, getRowId]);
+
+    const sortBy = useMemo(() => {
+        if (selectedRowIds?.length > 0) {
+            return [
+                ...(defaultSortBy || []),
+                ...[
+                    {
+                        id: '_selection_',
+                        desc: true,
+                    },
+                ],
+            ];
+        }
+
+        return undefined;
+    }, [defaultSortBy, selectedRowIds]);
+
     return (
         <FormField controlId={controlId} errorText={errorText} stretch={stretch}>
             <Table
@@ -56,8 +78,9 @@ const TableMapping = (props: UseFieldApiConfig) => {
                 items={items}
                 selectedRowIds={selectedRowIds}
                 columnDefinitions={columnDefinitions}
-                onSelectionChange={handleSelectionChange}
+                onSelectedRowIdsChange={handleSelectedRowIdsChange}
                 getRowId={getRowId}
+                sortBy={sortBy}
                 {...rest}
             />
         </FormField>

--- a/src/components/FormRendererTable/index.tsx
+++ b/src/components/FormRendererTable/index.tsx
@@ -69,7 +69,6 @@ const TableMapping = (props: UseFieldApiConfig) => {
                 columnDefinitions={columnDefinitions}
                 onSelectedRowIdsChange={handleSelectedRowIdsChange}
                 getRowId={getRowId}
-                sortBySelectionColumn={true}
                 {...rest}
             />
         </FormField>

--- a/src/components/Table/components/TableBody/index.tsx
+++ b/src/components/Table/components/TableBody/index.tsx
@@ -19,17 +19,10 @@ import clsx from 'clsx';
 import BaseTableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
-import {
-    Cell,
-    Row,
-    TableBodyProps as ReactTableBodyProps,
-    UseExpandedRowProps,
-    UseRowSelectRowProps,
-    UseGroupByRowProps,
-    UseGroupByCellProps,
-} from 'react-table';
+import { Cell, TableBodyProps as ReactTableBodyProps, UseGroupByCellProps } from 'react-table';
 import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
+import { Row } from '../../types';
 
 export interface TableBodyProps<D extends object> {
     reactTableBodyProps: ReactTableBodyProps;
@@ -57,44 +50,40 @@ export default function TableBody<D extends object>({
                     prepareRow(row);
                     return row;
                 })
-                .map(
-                    (
-                        row: Row<D> & Partial<UseExpandedRowProps<D> & UseRowSelectRowProps<D> & UseGroupByRowProps<D>>
-                    ) => (
-                        <TableRow
-                            selected={row.isSelected}
-                            {...row.getRowProps()}
-                            className={clsx({ [styles.aggregated]: row.isGrouped })}
-                        >
-                            {row.cells.map((cell: Partial<Cell<D> & UseGroupByCellProps<D>>) => {
-                                return (
-                                    <TableCell {...cell.getCellProps!()}>
-                                        {cell.isGrouped ? (
-                                            <div className={styles.cellAlign}>
-                                                <span className={clsx({ [styles.ellipsizeText]: !wrapText })}>
-                                                    <b>
-                                                        {cell.render!('Cell')} ({row.subRows.length})
-                                                    </b>
-                                                </span>
-                                                {row.isExpanded ? (
-                                                    <KeyboardArrowDown {...row.getToggleRowExpandedProps!()} />
-                                                ) : (
-                                                    <KeyboardArrowRight {...row.getToggleRowExpandedProps!()} />
-                                                )}
-                                            </div>
-                                        ) : (
-                                            // If the cell is aggregated, use the Aggregated
-                                            // renderer for cell, otherwise, just render the regular cell
-                                            <div className={clsx({ [styles.ellipsizeText]: !wrapText })}>
-                                                {cell!.render!(cell.isAggregated ? 'Aggregated' : 'Cell')}
-                                            </div>
-                                        )}
-                                    </TableCell>
-                                );
-                            })}
-                        </TableRow>
-                    )
-                )}
+                .map((row: Row<D>) => (
+                    <TableRow
+                        selected={row.isSelected}
+                        {...row.getRowProps()}
+                        className={clsx({ [styles.aggregated]: row.isGrouped })}
+                    >
+                        {row.cells.map((cell: Partial<Cell<D> & UseGroupByCellProps<D>>) => {
+                            return (
+                                <TableCell {...cell.getCellProps!()}>
+                                    {cell.isGrouped ? (
+                                        <div className={styles.cellAlign}>
+                                            <span className={clsx({ [styles.ellipsizeText]: !wrapText })}>
+                                                <b>
+                                                    {cell.render!('Cell')} ({row.subRows.length})
+                                                </b>
+                                            </span>
+                                            {row.isExpanded ? (
+                                                <KeyboardArrowDown {...row.getToggleRowExpandedProps!()} />
+                                            ) : (
+                                                <KeyboardArrowRight {...row.getToggleRowExpandedProps!()} />
+                                            )}
+                                        </div>
+                                    ) : (
+                                        // If the cell is aggregated, use the Aggregated
+                                        // renderer for cell, otherwise, just render the regular cell
+                                        <div className={clsx({ [styles.ellipsizeText]: !wrapText })}>
+                                            {cell!.render!(cell.isAggregated ? 'Aggregated' : 'Cell')}
+                                        </div>
+                                    )}
+                                </TableCell>
+                            );
+                        })}
+                    </TableRow>
+                ))}
         </BaseTableBody>
     );
 }

--- a/src/components/Table/components/TableHead/index.tsx
+++ b/src/components/Table/components/TableHead/index.tsx
@@ -29,6 +29,7 @@ import {
 } from 'react-table';
 import ArrowDropDown from '@material-ui/icons/ArrowDropDown';
 import { Stack } from '../../../../layouts';
+import { SELECTION_COLUMN_NAME } from '../../constants';
 
 export interface TableHeadProps<D extends object> {
     headerGroups: HeaderGroup<D>[];
@@ -57,7 +58,7 @@ export default function TableHead<D extends object>({ headerGroups, styles }: Ta
                             column.id !== '_all_' && (
                                 <TableCell {...column.getHeaderProps!()}>
                                     <Stack spacing="xs">
-                                        {column.canSort ? (
+                                        {column.canSort && column.id !== SELECTION_COLUMN_NAME ? (
                                             <TableSortLabel
                                                 {...column.getSortByToggleProps!()}
                                                 active={column.isSorted}

--- a/src/components/Table/components/TableHead/index.tsx
+++ b/src/components/Table/components/TableHead/index.tsx
@@ -29,7 +29,7 @@ import {
 } from 'react-table';
 import ArrowDropDown from '@material-ui/icons/ArrowDropDown';
 import { Stack } from '../../../../layouts';
-import { SELECTION_COLUMN_NAME } from '../../constants';
+import { SEARCH_COLUMN_NAME } from '../../constants';
 
 export interface TableHeadProps<D extends object> {
     headerGroups: HeaderGroup<D>[];
@@ -55,10 +55,10 @@ export default function TableHead<D extends object>({ headerGroups, styles }: Ta
                                     UseFiltersColumnProps<D>
                             >
                         ) =>
-                            column.id !== '_all_' && (
+                            column.id !== SEARCH_COLUMN_NAME && (
                                 <TableCell {...column.getHeaderProps!()}>
                                     <Stack spacing="xs">
-                                        {column.canSort && column.id !== SELECTION_COLUMN_NAME ? (
+                                        {column.canSort ? (
                                             <TableSortLabel
                                                 {...column.getSortByToggleProps!()}
                                                 active={column.isSorted}

--- a/src/components/Table/constants.ts
+++ b/src/components/Table/constants.ts
@@ -16,6 +16,7 @@
 
 export const SELECTION_COLUMN_NAME = '_selection_';
 export const EXPANDER_COLUMN_NAME = '_expander_';
+export const SEARCH_COLUMN_NAME = '_all_';
 
 export const DEFAULT_PAGE_SIZE = 10;
 export const DEFAULT_PAGE_SIZES = [10, 25, 50];

--- a/src/components/Table/constants.ts
+++ b/src/components/Table/constants.ts
@@ -15,3 +15,8 @@
  ******************************************************************************************************************** */
 
 export const SELECTION_COLUMN_NAME = '_selection_';
+export const EXPANDER_COLUMN_NAME = '_expander_';
+
+export const DEFAULT_PAGE_SIZE = 10;
+export const DEFAULT_PAGE_SIZES = [10, 25, 50];
+export const DEFAULT_DEBOUNCE_TIMER = 250;

--- a/src/components/Table/constants.ts
+++ b/src/components/Table/constants.ts
@@ -13,15 +13,5 @@
   See the License for the specific language governing permissions and
   limitations under the License.                                                                              *
  ******************************************************************************************************************** */
-import React, { StrictMode } from 'react';
-import NorthStarThemeProvider from '../src/components/NorthStarThemeProvider';
 
-const Decorator = (storyFn) => {
-    return (
-        <StrictMode>
-            <NorthStarThemeProvider>{storyFn()}</NorthStarThemeProvider>
-        </StrictMode>
-    );
-};
-
-export default Decorator;
+export const SELECTION_COLUMN_NAME = '_selection_';

--- a/src/components/Table/hooks/useTableColumnFilter/index.tsx
+++ b/src/components/Table/hooks/useTableColumnFilter/index.tsx
@@ -1,0 +1,113 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+
+import React, { useMemo } from 'react';
+import ChevronRightIcon from '@material-ui/icons/ChevronRight';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { Column, BooleanObject } from '../../types';
+import Checkbox from '../../../Checkbox';
+import { RadioButton } from '../../../RadioGroup';
+import { SELECTION_COLUMN_NAME } from '../../constants';
+
+export interface useTableColumnFilterProps<D extends object> {
+    columnDefinitions: Column<D>[];
+    disableRowSelect?: boolean;
+    disableExpand?: boolean;
+    multiSelect?: boolean;
+    isItemDisabled?: (item: D) => boolean;
+    showColumns: BooleanObject;
+    getRowId?: (originalRow: D, relativeIndex: number) => string;
+    selectedRowIdMap?: BooleanObject;
+    sortBySelectionColumn?: boolean;
+}
+
+const useTableColumnFilter = <D extends object>({
+    columnDefinitions,
+    showColumns,
+    disableRowSelect,
+    disableExpand,
+    multiSelect,
+    isItemDisabled,
+}: useTableColumnFilterProps<D>) => {
+    return useMemo(() => {
+        const columnsFiltered: any = columnDefinitions.filter((column: Column<D>) => showColumns[column.id || '']);
+        if (!disableExpand) {
+            columnsFiltered.unshift({
+                id: '_expander_',
+                Header: ({ getToggleAllRowsExpandedProps, isAllRowsExpanded }: any) => (
+                    <span {...getToggleAllRowsExpandedProps()}>
+                        {isAllRowsExpanded ? <ExpandMoreIcon /> : <ChevronRightIcon />}
+                    </span>
+                ),
+                Cell: ({ row }: any) =>
+                    row.canExpand ? (
+                        <span {...row.getToggleRowExpandedProps()}>
+                            {row.isExpanded ? <ExpandMoreIcon /> : <ChevronRightIcon />}
+                        </span>
+                    ) : null,
+            });
+        }
+        if (!disableRowSelect) {
+            columnsFiltered.unshift({
+                id: SELECTION_COLUMN_NAME,
+                width: 50,
+                defaultCanFilter: false,
+                disableFilters: true,
+                disableGlobalFilter: true,
+                Header: (props: any) => {
+                    return multiSelect && !isItemDisabled ? (
+                        <Checkbox
+                            controlId={`${SELECTION_COLUMN_NAME}_all`}
+                            ariaLabel="Checkbox to select all row items"
+                            {...props.getToggleAllRowsSelectedProps()}
+                        />
+                    ) : null;
+                },
+                Cell: ({ row, toggleAllRowsSelected }: any) => {
+                    const isSelectDisabled = !!isItemDisabled?.(row.original);
+                    return (
+                        <div>
+                            {multiSelect ? (
+                                <Checkbox
+                                    ariaLabel="Checkbox to select row item"
+                                    {...row.getToggleRowSelectedProps()}
+                                    disabled={isSelectDisabled}
+                                    controlId={row.id}
+                                />
+                            ) : (
+                                <RadioButton
+                                    name="select"
+                                    checked={row.isSelected}
+                                    controlId={row.id}
+                                    data-testid={row.id}
+                                    disabled={isSelectDisabled}
+                                    onChange={() => {
+                                        toggleAllRowsSelected(false);
+                                        row.toggleRowSelected(true);
+                                    }}
+                                />
+                            )}
+                        </div>
+                    );
+                },
+            });
+        }
+
+        return columnsFiltered;
+    }, [columnDefinitions, showColumns, disableRowSelect, disableExpand, multiSelect, isItemDisabled]);
+};
+
+export default useTableColumnFilter;

--- a/src/components/Table/hooks/useTableColumnFilter/index.tsx
+++ b/src/components/Table/hooks/useTableColumnFilter/index.tsx
@@ -29,9 +29,6 @@ export interface useTableColumnFilterProps<D extends object> {
     multiSelect?: boolean;
     isItemDisabled?: (item: D) => boolean;
     showColumns: BooleanObject;
-    getRowId?: (originalRow: D, relativeIndex: number) => string;
-    selectedRowIdMap?: BooleanObject;
-    sortBySelectionColumn?: boolean;
 }
 
 const useTableColumnFilter = <D extends object>({

--- a/src/components/Table/hooks/useTableColumnFilter/index.tsx
+++ b/src/components/Table/hooks/useTableColumnFilter/index.tsx
@@ -82,6 +82,7 @@ const useTableColumnFilter = <D extends object>({
                                     ariaLabel="Checkbox to select row item"
                                     {...row.getToggleRowSelectedProps()}
                                     disabled={isSelectDisabled}
+                                    data-testid={row.id}
                                     controlId={row.id}
                                 />
                             ) : (

--- a/src/components/Table/hooks/useTableColumnFilter/index.tsx
+++ b/src/components/Table/hooks/useTableColumnFilter/index.tsx
@@ -20,7 +20,7 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { Column, BooleanObject } from '../../types';
 import Checkbox from '../../../Checkbox';
 import { RadioButton } from '../../../RadioGroup';
-import { SELECTION_COLUMN_NAME } from '../../constants';
+import { SELECTION_COLUMN_NAME, EXPANDER_COLUMN_NAME } from '../../constants';
 
 export interface useTableColumnFilterProps<D extends object> {
     columnDefinitions: Column<D>[];
@@ -43,7 +43,7 @@ const useTableColumnFilter = <D extends object>({
         const columnsFiltered: any = columnDefinitions.filter((column: Column<D>) => showColumns[column.id || '']);
         if (!disableExpand) {
             columnsFiltered.unshift({
-                id: '_expander_',
+                id: EXPANDER_COLUMN_NAME,
                 Header: ({ getToggleAllRowsExpandedProps, isAllRowsExpanded }: any) => (
                     <span {...getToggleAllRowsExpandedProps()}>
                         {isAllRowsExpanded ? <ExpandMoreIcon /> : <ChevronRightIcon />}

--- a/src/components/Table/index.stories.tsx
+++ b/src/components/Table/index.stories.tsx
@@ -72,13 +72,8 @@ export const MultiSelect = () => {
             items={shortData}
             selectedRowIds={['id0000012', 'id0000013']}
             onSelectionChange={action('onSelectionChange')}
+            onSelectedRowIdsChange={action('onSelectedRowIdsChange')}
             getRowId={getRowId}
-            sortBy={[
-                {
-                    id: '_selection_',
-                    desc: true,
-                },
-            ]}
         />
     );
 };
@@ -109,6 +104,7 @@ export const SingleSelect = () => {
             multiSelect={false}
             selectedRowIds={['id0000012']}
             onSelectionChange={action('onSelectionChange')}
+            onSelectedRowIdsChange={action('onSelectedRowIdsChange')}
             getRowId={getRowId}
         />
     );

--- a/src/components/Table/index.stories.tsx
+++ b/src/components/Table/index.stories.tsx
@@ -73,6 +73,12 @@ export const MultiSelect = () => {
             selectedRowIds={['id0000012', 'id0000013']}
             onSelectionChange={action('onSelectionChange')}
             getRowId={getRowId}
+            sortBy={[
+                {
+                    id: '_selection_',
+                    desc: true,
+                },
+            ]}
         />
     );
 };
@@ -129,29 +135,42 @@ export const ColumnFilters = () => (
     />
 );
 
-export const ExpandedTable = () => (
-    <Table
-        tableTitle={'Expanded Table'}
-        columnDefinitions={columnDefinitions}
-        items={groupByData}
-        disableExpand={false}
-    />
-);
+export const ExpandedTable = () => {
+    const getRowId = useCallback((data) => data.id, []);
 
-export const Complex = () => (
-    <Table
-        onSelectionChange={action('onSelectionChange')}
-        tableTitle={'Complex Table'}
-        columnDefinitions={columnDefinitions}
-        items={longData}
-        sortBy={[
-            {
-                id: 'name',
-                desc: false,
-            },
-        ]}
-    />
-);
+    return (
+        <Table
+            tableTitle={'Expanded Table'}
+            columnDefinitions={columnDefinitions}
+            getRowId={getRowId}
+            items={groupByData}
+            disableExpand={false}
+            onSelectionChange={action('onSelectionChange')}
+            onSelectedRowIdsChange={action('onSelectedRowIdsChange')}
+        />
+    );
+};
+
+export const Complex = () => {
+    const getRowId = useCallback((data) => data.id, []);
+
+    return (
+        <Table
+            onSelectionChange={action('onSelectionChange')}
+            onSelectedRowIdsChange={action('onSelectedRowIdsChange')}
+            tableTitle={'Complex Table'}
+            columnDefinitions={columnDefinitions}
+            items={longData}
+            getRowId={getRowId}
+            sortBy={[
+                {
+                    id: 'name',
+                    desc: false,
+                },
+            ]}
+        />
+    );
+};
 
 export const WithActionGroup = () => {
     const [selected, setSelected] = useState<DataType[]>();

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -46,7 +46,7 @@ import ColumnsSelector from './components/ColumnsSelector';
 import ColumnsGrouping from './components/ColumnsGrouping';
 import DefaultColumnFilter from './components/DefaultColumnFilter';
 import useTableColumnFilter from './hooks/useTableColumnFilter';
-import { Column, BooleanObject, TableOptions, TableBaseOptions, TableInstance } from './types';
+import { Column, BooleanObject, TableOptions, TableBaseOptions, TableInstance, FetchDataOptions } from './types';
 
 import { convertBooleanObjectToArray, convertArrayToBooleanObject } from './utils/converter';
 
@@ -434,4 +434,4 @@ export default function Table<D extends object>({
 
 export type { CellProps, SortingRule } from 'react-table';
 
-export type { Column, Row };
+export type { Column, Row, TableOptions, FetchDataOptions, TableBaseOptions };

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -49,7 +49,6 @@ import useTableColumnFilter from './hooks/useTableColumnFilter';
 import { Column, BooleanObject, TableOptions, TableBaseOptions, TableInstance } from './types';
 
 import { convertBooleanObjectToArray, convertArrayToBooleanObject } from './utils/converter';
-import { SELECTION_COLUMN_NAME } from './constants';
 
 const DEFAULT_PAGE_SIZE = 10;
 const DEFAULT_PAGE_SIZES = [10, 25, 50];
@@ -152,7 +151,7 @@ export default function Table<D extends object>({
     isItemDisabled,
     errorText,
     onSelectedRowIdsChange,
-    sortBySelectionColumn = false,
+    sortBy: defaultSortBy = [],
     ...props
 }: TableBaseOptions<D>) {
     const styles = useStyles({});
@@ -165,20 +164,6 @@ export default function Table<D extends object>({
 
     const [controlledPageSize, setControlledPageSize] = useState(defaultPageSize);
 
-    const defaultSortBy = useMemo(() => {
-        return [
-            ...(props.sortBy || []),
-            ...(initialSelectedRowIds?.length > 0 && sortBySelectionColumn
-                ? [
-                      {
-                          id: SELECTION_COLUMN_NAME,
-                          desc: true,
-                      },
-                  ]
-                : []),
-        ];
-    }, [props.sortBy, sortBySelectionColumn, initialSelectedRowIds]);
-
     const columns = useTableColumnFilter({
         columnDefinitions,
         showColumns,
@@ -186,9 +171,6 @@ export default function Table<D extends object>({
         disableExpand,
         multiSelect,
         isItemDisabled,
-        sortBySelectionColumn,
-        getRowId,
-        selectedRowIdMap,
     });
 
     const rowCount = useMemo(() => {

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -47,12 +47,8 @@ import ColumnsGrouping from './components/ColumnsGrouping';
 import DefaultColumnFilter from './components/DefaultColumnFilter';
 import useTableColumnFilter from './hooks/useTableColumnFilter';
 import { Column, BooleanObject, TableOptions, TableBaseOptions, TableInstance, FetchDataOptions } from './types';
-
 import { convertBooleanObjectToArray, convertArrayToBooleanObject } from './utils/converter';
-
-const DEFAULT_PAGE_SIZE = 10;
-const DEFAULT_PAGE_SIZES = [10, 25, 50];
-const DEFAULT_DEBOUNCE_TIMER = 250;
+import { DEFAULT_DEBOUNCE_TIMER, DEFAULT_PAGE_SIZE, DEFAULT_PAGE_SIZES } from './constants';
 
 const useStyles = makeStyles((theme) => ({
     tableBar: {

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -202,10 +202,6 @@ export interface TableBaseOptions<D extends object> {
      * Determines whether a given item is disabled. If an item is disabled, the user can't select it.
      * */
     isItemDisabled?: (item: D) => boolean;
-    /**
-     * Indicate whether sort by the selection column with selected first initially.
-     */
-    sortBySelectionColumn?: boolean;
 }
 
 export type TableInstance<D extends object> = {} & TableBaseInstance<D> &

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -1,0 +1,224 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+import { ReactNode } from 'react';
+import {
+    Column as ReactTableColumn,
+    Row as ReactTableRow,
+    SortingRule,
+    TableInstance as TableBaseInstance,
+    TableState,
+    UseExpandedOptions,
+    UseExpandedRowProps,
+    UseFiltersColumnOptions,
+    UseFiltersInstanceProps,
+    UseFiltersOptions,
+    UseGlobalFiltersColumnOptions,
+    UseGlobalFiltersInstanceProps,
+    UseGlobalFiltersOptions,
+    UseGlobalFiltersState,
+    UseGroupByInstanceProps,
+    UseGroupByOptions,
+    UseGroupByRowProps,
+    UsePaginationInstanceProps,
+    UsePaginationOptions,
+    UsePaginationState,
+    UseRowSelectInstanceProps,
+    UseRowSelectOptions,
+    UseRowSelectRowProps,
+    UseRowSelectState,
+    UseSortByOptions,
+    UseSortByState,
+} from 'react-table';
+
+export type Row<D extends object> = ReactTableRow<D> &
+    Partial<UseExpandedRowProps<D> & UseRowSelectRowProps<D> & UseGroupByRowProps<D>>;
+
+export type Column<D extends object> = {} & ReactTableColumn<D> &
+    Partial<UseFiltersColumnOptions<D> & UseGlobalFiltersColumnOptions<D>>;
+
+export type BooleanObject = { [key: string]: boolean };
+
+export interface TableOptions<D extends object>
+    extends UseExpandedOptions<D>,
+        UseRowSelectOptions<D>,
+        UseFiltersOptions<D>,
+        UseGlobalFiltersOptions<D>,
+        UseGroupByOptions<D>,
+        UseSortByOptions<D>,
+        UseFiltersOptions<D>,
+        UsePaginationOptions<D>,
+        Record<string, any> {}
+
+export interface FetchDataOptions {
+    pageSize?: number;
+    pageIndex?: number;
+    groupBy?: string[];
+    showColumns?: string[];
+    sortBy?: SortingRule<string>[];
+    filterText?: string;
+}
+
+export interface TableBaseOptions<D extends object> {
+    /**
+     * The actions displayed on the top right corner.
+     */
+    actionGroup?: ReactNode;
+    /**
+     * The items serve as data source for table rows. The display of a row is handled by the column definition in the columnDefinitions property. <br/>
+     * Remark: if you want to change the set of items make sure you provide a new array. Any modification to the same array will not be reflected in the view.
+     */
+    items?: D[] | null;
+    /**
+     * Describes the columns to be displayed in the table, and how each item is rendered.
+     * */
+    columnDefinitions: Column<D>[];
+    /**
+     * The default column filter component
+     * */
+    defaultColumnFilter?: ReactNode;
+    /**
+     * The default grouping ids
+     * */
+    defaultGroups?: string[];
+    /**
+     * Disable pagination
+     * */
+    disablePagination?: boolean;
+    /**
+     * Disable setting toolbar
+     * */
+    disableSettings?: boolean;
+    /**
+     * Disable sortBy
+     * */
+    disableSortBy?: boolean;
+    /**
+     * Disable search filters */
+    disableFilters?: boolean;
+    /**
+     * Disable column filters
+     * */
+    disableColumnFilters?: boolean;
+    /**
+     * Disable expand
+     * */
+    disableExpand?: boolean;
+    /**
+     * Disable groupBy
+     * */
+    disableGroupBy?: boolean;
+    /**
+     * Disable row select
+     * */
+    disableRowSelect?: boolean;
+    /**
+     * The default index of the page that should be displayed
+     * */
+    defaultPageIndex?: number;
+    /**
+     * The default number of rows on any given page
+     * */
+    defaultPageSize?: number;
+    /**
+     * Indicates the row select is multiselect or not, when disableRowSelect is false
+     * */
+    multiSelect?: boolean;
+    /**
+     * Renders the table as being in a loading state.
+     * */
+    loading?: boolean;
+    /**
+     * Text to be displayed in case of a data fetching error.
+     * */
+    errorText?: string;
+    /**
+     * Triggers when an row/rows are selected or the filters are changed. <br/>
+     * The callback argument only includes the rows after taking filters (global filter or column filters) result into account. <br/>
+     * See also <i>onSelectedRowIdsChange</i>.
+     * */
+    onSelectionChange?: (selectedItems: D[]) => void;
+    /**
+     * The list of available page sizes
+     * */
+    pageSizes?: number[];
+    /**
+     * The total number of rows
+     * */
+    rowCount?: number;
+    /**
+     * The title of the table
+     * */
+    tableTitle?: string;
+    /**
+     * The description of the table
+     * */
+    tableDescription?: string;
+    /**
+     * Whether the text in the table cell is wrapped
+     * */
+    wrapText?: boolean;
+    /**
+     * The list of ids of the row(s) selected. To support this, you need to have the getRowId set. Otherwise, the index will be used.
+     * */
+    selectedRowIds?: string[];
+    /**
+     * Triggers when an row/rows are selected. <br/>
+     * Use <b>getRowId</b> to specify how Table constructs each row's underlying <i>id</i> property. <br/>
+     * This callback argument includes the rows the users select no matter whether the filters filter out the selections. <br/>
+     * See also <i>onSelectionChange</i>.
+     **/
+    onSelectedRowIdsChange?: (selectedRowIds: string[]) => void;
+    /**
+     * Handler for updating data when table options (pageSize, pageIndex, filterText) change. <br/>
+     * If the handler is not provided, data is processed automatically.
+     * */
+    onFetchData?: ((options: FetchDataOptions) => void) | null;
+    /**
+     * Instruct how Table constructs each row's underlying <i>id</i> property. Must be <b>memoized</b>.
+     * */
+    getRowId?: (originalRow: D, relativeIndex: number) => string;
+    /**
+     * Instruct how Table detects subrows. Must be <b>memoized</b>.
+     * */
+    getSubRows?: (originalRow: D, relativeIndex: number) => D[];
+    /**
+     * The initial columns to sort by
+     * */
+    sortBy?: SortingRule<string>[];
+    /**
+     * Determines whether a given item is disabled. If an item is disabled, the user can't select it.
+     * */
+    isItemDisabled?: (item: D) => boolean;
+    /**
+     * Indicate whether sort by the selection column with selected first initially.
+     */
+    sortBySelectionColumn?: boolean;
+}
+
+export type TableInstance<D extends object> = {} & TableBaseInstance<D> &
+    Partial<
+        UsePaginationInstanceProps<D> &
+            UseRowSelectInstanceProps<D> &
+            UseFiltersInstanceProps<D> &
+            UseGlobalFiltersInstanceProps<D> &
+            UseGroupByInstanceProps<D>
+    > &
+    Partial<{
+        state: Partial<
+            TableState & UsePaginationState<D> & UseSortByState<D> & UseRowSelectState<D> & UseGlobalFiltersState<D>
+        >;
+    }> &
+    Partial<{ selectedFlatRows: Row<D>[] }>;

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -145,7 +145,7 @@ export interface TableBaseOptions<D extends object> {
      * */
     errorText?: string;
     /**
-     * Triggers when an row/rows are selected or the filters are changed. <br/>
+     * Triggers when a row/rows are selected or the selection are filtered out by filters. <br/>
      * The callback argument only includes the rows after taking filters (global filter or column filters) result into account. <br/>
      * See also <i>onSelectedRowIdsChange</i>.
      * */
@@ -175,7 +175,7 @@ export interface TableBaseOptions<D extends object> {
      * */
     selectedRowIds?: string[];
     /**
-     * Triggers when an row/rows are selected. <br/>
+     * Triggers when a row/rows are selected. <br/>
      * Use <b>getRowId</b> to specify how Table constructs each row's underlying <i>id</i> property. <br/>
      * This callback argument includes the rows the users select no matter whether the filters filter out the selections. <br/>
      * See also <i>onSelectionChange</i>.

--- a/src/components/Table/utils/converter/index.test.ts
+++ b/src/components/Table/utils/converter/index.test.ts
@@ -1,0 +1,48 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+
+import { convertArrayToBooleanObject, convertBooleanObjectToArray } from '.';
+
+describe('converter', () => {
+    describe('convertArrayToBooleanObject', () => {
+        it('converts string array to boolean object', () => {
+            const input = ['1', '3', '5', '11'];
+            const output = convertArrayToBooleanObject(input);
+            const expectedOutput = {
+                '1': true,
+                '3': true,
+                '5': true,
+                '11': true,
+            };
+            expect(output).toEqual(expectedOutput);
+        });
+    });
+
+    describe('convertBooleanObjectToArray', () => {
+        it('converts boolean object to string array', () => {
+            const input = {
+                '1': true,
+                '3': true,
+                '5': true,
+                '7': false,
+                '11': true,
+            };
+            const output = convertBooleanObjectToArray(input);
+            const expectedOutput = ['1', '3', '5', '11'];
+            expect(output).toEqual(expectedOutput);
+        });
+    });
+});

--- a/src/components/Table/utils/converter/index.ts
+++ b/src/components/Table/utils/converter/index.ts
@@ -1,0 +1,26 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+
+import { BooleanObject } from '../../types';
+
+export const convertArrayToBooleanObject = (arr: string[]): BooleanObject =>
+    arr.reduce((map, id) => ({ ...map, [id]: true }), {});
+
+export const convertBooleanObjectToArray = (selectedRowIdsMap: BooleanObject): string[] =>
+    Object.keys(selectedRowIdsMap).reduce(
+        (arr: string[], key: string) => [...arr, ...(selectedRowIdsMap[key] ? [key] : [])],
+        []
+    );

--- a/src/layouts/AppLayout/index.stories.tsx
+++ b/src/layouts/AppLayout/index.stories.tsx
@@ -36,6 +36,9 @@ import { Default as GeneralInfo } from '../../components/KeyValuePair/index.stor
 export default {
     component: AppLayout,
     title: 'AppLayout',
+    parameters: {
+        layout: 'fullscreen',
+    },
 };
 
 const header = <Header title="HelloWorld" logoPath="img/logo-light-short.png" hideHeaderBelow="sm" />;
@@ -333,7 +336,7 @@ export const CustomHeader = () => {
             paddingY="auto"
             color="primary.contrastText"
         >
-            Custom Header
+            Header
         </Box>
     );
     return (

--- a/src/utils/isEqual/index.test.ts
+++ b/src/utils/isEqual/index.test.ts
@@ -1,0 +1,63 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+
+import isEqual from '.';
+
+describe('isEqual', () => {
+    describe('performs deep comparision on two string arrays', () => {
+        it('returns true for two empty arrays', () => {
+            const arr1: string[] = [];
+            const arr2: string[] = [];
+            const result = isEqual(arr1, arr2);
+            expect(result).toEqual(true);
+        });
+
+        it('returns true for two arrays have identical length and identical items', () => {
+            const arr1 = ['1', '2', '3', '4'];
+            const arr2 = ['1', '2', '3', '4'];
+            const result = isEqual(arr1, arr2);
+            expect(result).toEqual(true);
+        });
+
+        it('returns true for two arrays have identical length and identical items but in different order', () => {
+            const arr1 = ['1', '4', '3', '3'];
+            const arr2 = ['4', '3', '3', '1'];
+            const result = isEqual(arr1, arr2);
+            expect(result).toEqual(true);
+        });
+
+        it('returns false when two arrays have different lengths', () => {
+            const arr1 = ['1', '3', '5', '11'];
+            const arr2 = ['3', '5'];
+            const result = isEqual(arr1, arr2);
+            expect(result).toEqual(false);
+        });
+
+        it('returns false when two arrays are different in items', () => {
+            const arr1 = ['1', '3', '5', '11'];
+            const arr2 = ['a', 'b', 'c', 'd'];
+            const result = isEqual(arr1, arr2);
+            expect(result).toEqual(false);
+        });
+
+        it('returns false when two arrays are differents in even one item', () => {
+            const arr1 = ['1', '3', '5', '11'];
+            const arr2 = ['1', '3', '5', '1'];
+            const result = isEqual(arr1, arr2);
+            expect(result).toEqual(false);
+        });
+    });
+});

--- a/src/utils/isEqual/index.test.ts
+++ b/src/utils/isEqual/index.test.ts
@@ -39,6 +39,34 @@ describe('isEqual', () => {
             expect(result).toEqual(true);
         });
 
+        it('returns true if two arrays are both undefined', () => {
+            const arr1 = undefined;
+            const arr2 = undefined;
+            const result = isEqual(arr1, arr2);
+            expect(result).toEqual(true);
+        });
+
+        it('returns true if two arrays are both null', () => {
+            const arr1 = null;
+            const arr2 = null;
+            const result = isEqual(arr1, arr2);
+            expect(result).toEqual(true);
+        });
+
+        it('returns false if one of arrays are undefined and another null', () => {
+            const arr1 = undefined;
+            const arr2 = null;
+            const result = isEqual(arr1, arr2);
+            expect(result).toEqual(true);
+        });
+
+        it('returns false if one of arrays are undefined and another is an array', () => {
+            const arr1 = undefined;
+            const arr2: string[] = [];
+            const result = isEqual(arr1, arr2);
+            expect(result).toEqual(false);
+        });
+
         it('returns false when two arrays have different lengths', () => {
             const arr1 = ['1', '3', '5', '11'];
             const arr2 = ['3', '5'];
@@ -46,14 +74,14 @@ describe('isEqual', () => {
             expect(result).toEqual(false);
         });
 
-        it('returns false when two arrays are different in items', () => {
+        it('returns false when two arrays have different items', () => {
             const arr1 = ['1', '3', '5', '11'];
             const arr2 = ['a', 'b', 'c', 'd'];
             const result = isEqual(arr1, arr2);
             expect(result).toEqual(false);
         });
 
-        it('returns false when two arrays are differents in even one item', () => {
+        it('returns false when two arrays have differents in even just one item', () => {
             const arr1 = ['1', '3', '5', '11'];
             const arr2 = ['1', '3', '5', '1'];
             const result = isEqual(arr1, arr2);

--- a/src/utils/isEqual/index.ts
+++ b/src/utils/isEqual/index.ts
@@ -13,9 +13,24 @@
   See the License for the specific language governing permissions and
   limitations under the License.                                                                              *
  ******************************************************************************************************************** */
-const isEqual = (arr1: string[], arr2: string[]) => {
-    const array2Sorted = [...arr2].sort();
-    return arr1.length === arr2.length && [...arr1].sort().every((value, index) => value === array2Sorted[index]);
+const isEqual = (arr1?: string[] | null, arr2?: string[] | null) => {
+    if (!arr1 && !arr2) {
+        return true;
+    }
+
+    if (!arr1 || !arr2) {
+        return false;
+    }
+
+    const lenArr1 = arr1!.length;
+    const lenArr2 = arr2!.length;
+
+    if (lenArr1 !== lenArr2) {
+        return false;
+    }
+
+    const array2Sorted = [...arr2!].sort();
+    return arr1!.length === arr2!.length && [...arr1!].sort().every((value, index) => value === array2Sorted[index]);
 };
 
 export default isEqual;

--- a/src/utils/isEqual/index.ts
+++ b/src/utils/isEqual/index.ts
@@ -1,0 +1,21 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+const isEqual = (arr1: string[], arr2: string[]) => {
+    const array2Sorted = [...arr2].sort();
+    return arr1.length === arr2.length && [...arr1].sort().every((value, index) => value === array2Sorted[index]);
+};
+
+export default isEqual;

--- a/src/utils/isEqual/index.ts
+++ b/src/utils/isEqual/index.ts
@@ -22,15 +22,12 @@ const isEqual = (arr1?: string[] | null, arr2?: string[] | null) => {
         return false;
     }
 
-    const lenArr1 = arr1!.length;
-    const lenArr2 = arr2!.length;
-
-    if (lenArr1 !== lenArr2) {
+    if (arr1!.length !== arr2!.length) {
         return false;
     }
 
     const array2Sorted = [...arr2!].sort();
-    return arr1!.length === arr2!.length && [...arr1!].sort().every((value, index) => value === array2Sorted[index]);
+    return [...arr1!].sort().every((value, index) => value === array2Sorted[index]);
 };
 
 export default isEqual;


### PR DESCRIPTION
*Description of changes:*

The existing event **onSelectionChange** fired by the Table is hooked to the changes of react-table **selectedFlatRows**. It is affected by both the row selection changes and the filters (either global filter or column filter) to only return the selected rows within the current applied filter. The event is fired when the filter value is changed.   

In most of scenarios, it is what users expect. However, if it is used in the form for users to select one or multiple value, the users may be confused. It will be nice that we have two events to cater for different use cases.

This PR also: 
1. Refactor the Table component to move some logic out of **index.tsx** file
2. Update the FormRendererTable component to use the new event so that it always returns what users have selected
3. Remove the padding in the storybook given that storybook has an existing padding already
4. Display the AppLayout in the fullscreen mode 
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
