### PR TITLE
change the order of the child components in the document

### DIFF
--- a/src/charts/BarChart/BarChart.md
+++ b/src/charts/BarChart/BarChart.md
@@ -18,11 +18,11 @@ const sampleData = [
 
 <Container>
     <BarChart title="Bar Chart - two data series" width={400} height={200} data={sampleData}>
-        <Bar dataKey="pv" fill={NORTHSTAR_COLORS.ORANGE} stroke={NORTHSTAR_COLORS.ORANGE} />
-        <Bar dataKey="uv" fill={NORTHSTAR_COLORS.BLUE} stroke={NORTHSTAR_COLORS.BLUE}/>
         <XAxis dataKey="name" />
         <YAxis />
         <Tooltip />
+        <Bar dataKey="pv" fill={NORTHSTAR_COLORS.ORANGE} stroke={NORTHSTAR_COLORS.ORANGE} />
+        <Bar dataKey="uv" fill={NORTHSTAR_COLORS.BLUE} stroke={NORTHSTAR_COLORS.BLUE}/>
     </BarChart>
 </Container>
 ```


### PR DESCRIPTION
to display bars on top of the tooltip.

*Issue #, if available:*

*Description of changes:*
Tooltip hide bars onHover if we follow the document. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
