### PR TITLE
fix: Remove sourcemap to address the build warnings in the consumers

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,8 +1,4 @@
 {
-    branches: [
-                {name: 'main'},
-                {name: 'next', channel: 'next'}
-            ],
     "plugins": [
         ["@semantic-release/commit-analyzer", {
             "preset": "angular",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   ],
   "scripts": {
     "build:build-readme": "cp ./README_NPM_PACKAGE.md ./build/README.md && cat ./docs/GettingStarted.md >> ./build/README.md",
-    "build:copy-file": "cp ./package.json ./build/",
-    "build": "tsc --build tsconfig.build.json && yarn build:copy-file && yarn build:build-readme",
+    "build:build-package-json": "cat package.json | jq 'del(.devDependencies, .resolutions, .scripts, .\"lint-staged\")' > ./build/package.json",
+    "build": "tsc --build tsconfig.build.json && yarn build:build-package-json && yarn build:build-readme",
     "build:esm": "tsc --build tsconfig.build.esm.json",
     "check:all": "yarn test:ci && yarn build && yarn storybook:build && yarn styleguide:build",
     "generate:attribution": "generate-attribution && mv oss-attribution/attribution.txt LICENSE-THIRD-PARTY",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
         "outDir": "build",
         "skipLibCheck": true,
         "rootDirs": ["src"],
-        "sourceMap": true,
+        "sourceMap": false,
         "strict": true,
         "strictNullChecks": true,
         "suppressImplicitAnyIndexErrors": true,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Remove the sourceMap from the built npm package given that the source code is not distributed, which causes build warnings in the consumer apps created using default create-react-app 5 settings. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
