### PR TITLE
fix(Tabs): Dynamically update activeId should update the active tab. Closes #562

### DIFF
--- a/src/components/Tabs/index.stories.tsx
+++ b/src/components/Tabs/index.stories.tsx
@@ -77,6 +77,7 @@ export const DynamicActiveId = () => {
     useEffect(() => {
         setTimeout(() => setActiveId('first'), 3000);
         setTimeout(() => setActiveId('second'), 6000);
+        setTimeout(() => setActiveId('second'), 9000);
     }, []);
 
     return <Tabs tabs={tabs} onChange={action('onChange')} activeId={activeId} variant="container" />;

--- a/src/components/Tabs/index.stories.tsx
+++ b/src/components/Tabs/index.stories.tsx
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.                                                                              *
  ******************************************************************************************************************** */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Tabs from '.';
 import Box from '../../layouts/Box';
 import { action } from '@storybook/addon-actions';
@@ -69,4 +69,15 @@ export const NoPaddingContainer = () => {
             variant="container"
         />
     );
+};
+
+export const DynamicActiveId = () => {
+    const [activeId, setActiveId] = useState('second');
+
+    useEffect(() => {
+        setTimeout(() => setActiveId('first'), 3000);
+        setTimeout(() => setActiveId('second'), 6000);
+    }, []);
+
+    return <Tabs tabs={tabs} onChange={action('onChange')} activeId={activeId} variant="container" />;
 };

--- a/src/components/Tabs/index.test.tsx
+++ b/src/components/Tabs/index.test.tsx
@@ -115,4 +115,19 @@ describe('Tabs', () => {
 
         expect(labelContent).toBeVisible();
     });
+
+    const TabsWithActiveId = ({ activeId }: { activeId: string }) => {
+        return <Tabs tabs={tabs} activeId={activeId} />;
+    };
+
+    it('change active Id with the activeId changed', () => {
+        const props = { tabs };
+        const { getByText, rerender } = render(<TabsWithActiveId {...props} activeId="second" />);
+        expect(getByText(tabs[0].content)).not.toBeVisible();
+        expect(getByText(tabs[1].content)).toBeVisible();
+
+        rerender(<TabsWithActiveId {...props} activeId="first" />);
+        expect(getByText(tabs[0].content)).toBeVisible();
+        expect(getByText(tabs[1].content)).not.toBeVisible();
+    });
 });

--- a/src/components/Tabs/index.test.tsx
+++ b/src/components/Tabs/index.test.tsx
@@ -129,5 +129,15 @@ describe('Tabs', () => {
         rerender(<TabsWithActiveId {...props} activeId="first" />);
         expect(getByText(tabs[0].content)).toBeVisible();
         expect(getByText(tabs[1].content)).not.toBeVisible();
+
+        const tab = getByText(THIRD_TAB_LABEL).closest('button');
+
+        if (tab) {
+            fireEvent.click(tab);
+        }
+
+        expect(getByText(tabs[0].content)).not.toBeVisible();
+        expect(getByText(tabs[1].content)).not.toBeVisible();
+        expect(getByText(tabs[2].content)).toBeVisible();
     });
 });

--- a/src/components/Tabs/index.test.tsx
+++ b/src/components/Tabs/index.test.tsx
@@ -120,7 +120,7 @@ describe('Tabs', () => {
         return <Tabs tabs={tabs} activeId={activeId} />;
     };
 
-    it('change active Id with the activeId changed', () => {
+    it('change active tab with the activeId changed', () => {
         const props = { tabs };
         const { getByText, rerender } = render(<TabsWithActiveId {...props} activeId="second" />);
         expect(getByText(tabs[0].content)).not.toBeVisible();

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -22,6 +22,7 @@ import Tab from '@material-ui/core/Tab';
 import MuiTabs from '@material-ui/core/Tabs';
 import Container from '../../layouts/Container';
 import Box from '../../layouts/Box';
+import usePrevious from '../../hooks/usePrevious';
 
 const useStyles = makeStyles((theme) => ({
     tab: {
@@ -106,6 +107,7 @@ const Tabs = ({
 }: TabsProps): ReactElement => {
     const classes = useStyles({});
     const [value, setValue] = React.useState(0);
+    const previousActiveId = usePrevious<string>(activeId);
     const handleChange = useCallback(
         (_event: React.ChangeEvent<{}>, index: number) => {
             onChange?.(tabs[index].id);
@@ -115,11 +117,14 @@ const Tabs = ({
     );
 
     useEffect(() => {
-        const tabIndex = tabs.findIndex((tab) => tab.id === activeId);
-        if (tabIndex !== -1 && tabIndex !== value) {
-            setValue(tabIndex);
+        if (previousActiveId !== activeId) {
+            // Only fired when activeId change
+            const tabIndex = tabs.findIndex((tab) => tab.id === activeId);
+            if (tabIndex !== -1 && tabIndex !== value) {
+                setValue(tabIndex);
+            }
         }
-    }, [activeId, tabs, value]);
+    }, [activeId, previousActiveId, tabs, value]);
 
     const testId = props['data-testid'] || 'tabs';
 

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -99,7 +99,7 @@ function TabPanel({ children, value, index, paddingContentArea, ...props }: TabP
  */
 const Tabs = ({
     tabs,
-    activeId = '',
+    activeId,
     variant = 'default',
     paddingContentArea = true,
     onChange,
@@ -120,7 +120,7 @@ const Tabs = ({
     );
 
     useEffect(() => {
-        if (previousActiveId !== activeId) {
+        if (typeof activeId !== 'undefined' && previousActiveId !== activeId) {
             // Only fired when activeId change
             const tabIndex = tabs.findIndex((tab) => tab.id === activeId);
             if (tabIndex !== -1 && tabIndex !== value) {

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -106,8 +106,11 @@ const Tabs = ({
     ...props
 }: TabsProps): ReactElement => {
     const classes = useStyles({});
-    const [value, setValue] = React.useState(0);
-    const previousActiveId = usePrevious<string>(activeId);
+    const [value, setValue] = React.useState(() => {
+        const tabIndex = tabs.findIndex((tab) => tab.id === activeId);
+        return tabIndex === -1 ? 0 : tabIndex;
+    });
+    const previousActiveId = usePrevious(activeId);
     const handleChange = useCallback(
         (_event: React.ChangeEvent<{}>, index: number) => {
             onChange?.(tabs[index].id);

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -14,7 +14,7 @@
   limitations under the License.                                                                              *
  ******************************************************************************************************************** */
 
-import React, { ReactElement, ReactNode, useCallback, useMemo } from 'react';
+import React, { ReactElement, ReactNode, useCallback, useEffect, useMemo } from 'react';
 import clsx from 'clsx';
 import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
@@ -105,8 +105,7 @@ const Tabs = ({
     ...props
 }: TabsProps): ReactElement => {
     const classes = useStyles({});
-    const tabIndex = tabs.findIndex((tab) => tab.id === activeId);
-    const [value, setValue] = React.useState(tabIndex === -1 ? 0 : tabIndex);
+    const [value, setValue] = React.useState(0);
     const handleChange = useCallback(
         (_event: React.ChangeEvent<{}>, index: number) => {
             onChange?.(tabs[index].id);
@@ -114,6 +113,13 @@ const Tabs = ({
         },
         [onChange, tabs]
     );
+
+    useEffect(() => {
+        const tabIndex = tabs.findIndex((tab) => tab.id === activeId);
+        if (tabIndex !== -1 && tabIndex !== value) {
+            setValue(tabIndex);
+        }
+    }, [activeId, tabs, value]);
 
     const testId = props['data-testid'] || 'tabs';
 

--- a/src/hooks/usePrevious/index.test.tsx
+++ b/src/hooks/usePrevious/index.test.tsx
@@ -1,0 +1,53 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+import React from 'react';
+import usePrevious from '.';
+import { render } from '@testing-library/react';
+
+const Wrapper = <T extends unknown>({ id }: { id: T }) => {
+    const previousId = usePrevious(id);
+    return <div>{String(previousId)}</div>;
+};
+
+describe('usePrevious', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should return previous string value', () => {
+        const { getByText, queryByText, rerender } = render(<Wrapper id="version1" />);
+        expect(queryByText('version1')).toBeNull();
+        rerender(<Wrapper id="version2" />);
+        expect(getByText('version1')).toBeInTheDocument();
+        expect(queryByText('version2')).toBeNull();
+        rerender(<Wrapper id="version3" />);
+        expect(queryByText('version1')).toBeNull();
+        expect(queryByText('version2')).toBeInTheDocument();
+        expect(queryByText('version3')).toBeNull();
+    });
+
+    it('should return previous number value', () => {
+        const { getByText, queryByText, rerender } = render(<Wrapper id={1} />);
+        expect(queryByText('1')).toBeNull();
+        rerender(<Wrapper id={2} />);
+        expect(getByText('1')).toBeInTheDocument();
+        expect(queryByText('2')).toBeNull();
+        rerender(<Wrapper id={3} />);
+        expect(queryByText('1')).toBeNull();
+        expect(queryByText('2')).toBeInTheDocument();
+        expect(queryByText('3')).toBeNull();
+    });
+});

--- a/src/hooks/usePrevious/index.tsx
+++ b/src/hooks/usePrevious/index.tsx
@@ -1,0 +1,26 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+import { useRef, useEffect } from 'react';
+
+const usePrevious = <T extends unknown>(value: T) => {
+    const ref = useRef<T>();
+    useEffect(() => {
+        ref.current = value;
+    }, [value]);
+    return ref.current;
+};
+
+export default usePrevious;

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "sourceMap": false,
+  },
   "extends": "./tsconfig.json",
   "exclude": [
     "node_modules",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
         "outDir": "build",
         "skipLibCheck": true,
         "rootDirs": ["src"],
-        "sourceMap": false,
+        "sourceMap": true,
         "strict": true,
         "strictNullChecks": true,
         "suppressImplicitAnyIndexErrors": true,


### PR DESCRIPTION
*Issue #, if available:*

#562 

*Description of changes:*

Currently, activeId in Tabs component is only used as initial default value to determine the active Tab. Dynamically change activeId will not update the active Tab. This PR is to allow the usage of dynamically set activeId while keeping the original user experiences (onChange to trigger change without binding to activeId).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
