### PR TITLE
feat: Be able to disable next/submit button in Wizard.

### DIFF
--- a/src/components/Wizard/components/WizardInner/index.tsx
+++ b/src/components/Wizard/components/WizardInner/index.tsx
@@ -35,6 +35,7 @@ export interface WizardInnerProps {
     nextButtonText?: string;
     submitButtonText?: string;
     isLoadingNextStep?: boolean;
+    isDisabledNextStep?: boolean;
     onCancelButtonClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
     onPreviousButtonClick: () => void;
     onNextButtonClick: () => void;
@@ -58,6 +59,7 @@ const WizardInner: FunctionComponent<WizardInnerProps> = ({
     submitButtonText = 'Submit',
     optionalText = 'optional',
     isLoadingNextStep = false,
+    isDisabledNextStep = false,
     disableStepNavigation = false,
     onNextButtonClick,
     onPreviousButtonClick,
@@ -80,6 +82,7 @@ const WizardInner: FunctionComponent<WizardInnerProps> = ({
                 <Button
                     variant="primary"
                     loading={isLoadingNextStep}
+                    disabled={isDisabledNextStep}
                     onClick={activeStepIndex === stepCount - 1 ? onSubmitButtonClick : onNextButtonClick}
                 >
                     {activeStepIndex === stepCount - 1 ? submitButtonText : nextButtonText}
@@ -90,6 +93,7 @@ const WizardInner: FunctionComponent<WizardInnerProps> = ({
         activeStepIndex,
         stepCount,
         isLoadingNextStep,
+        isDisabledNextStep,
         cancelButtonText,
         nextButtonText,
         previousButtonText,

--- a/src/components/Wizard/index.test.tsx
+++ b/src/components/Wizard/index.test.tsx
@@ -50,7 +50,7 @@ describe('Wizard', () => {
             </Router>
         );
 
-        expect(getByText('Next')).toBeEnabled();
+        expect(getByText('Next').parentNode).toBeEnabled();
     });
 
     it('Ensure isDisabledNextStep props can disable Next button.', () => {

--- a/src/components/Wizard/index.test.tsx
+++ b/src/components/Wizard/index.test.tsx
@@ -42,6 +42,28 @@ const steps = [
 describe('Wizard', () => {
     afterEach(cleanup);
 
+    it('Ensure isDisabledNextStep props is enbled by default.', () => {
+        const history = createMemoryHistory();
+        const { getByText } = render(
+            <Router history={history}>
+                <Wizard steps={steps} />
+            </Router>
+        );
+
+        expect(getByText('Next')).toBeEnabled();
+    });
+
+    it('Ensure isDisabledNextStep props can disable Next button.', () => {
+        const history = createMemoryHistory();
+        const { getByText } = render(
+            <Router history={history}>
+                <Wizard steps={steps} isDisabledNextStep />
+            </Router>
+        );
+
+        expect(getByText('Next').parentNode).toBeDisabled();
+    });
+
     it('renders Wizard step 1', () => {
         const history = createMemoryHistory();
         const { getByText, getAllByText, getByTestId } = render(

--- a/src/components/Wizard/index.tsx
+++ b/src/components/Wizard/index.tsx
@@ -50,6 +50,8 @@ export interface WizardProps {
     optionalText?: string;
     /** Renders the next or submit button in a loading state. Use this if you need to wait for a response from the server before the user can proceed to the next step, such as during server-side validation or retrieving the next step's information.*/
     isLoadingNextStep?: boolean;
+    /** Renders the next or submit button in disabled state. Use this if you need to disable the next button until some conditions are met and then only let the user be able to proceed to the next step, such as in the case of client-side validation.*/
+    isDisabledNextStep?: boolean;
     /** Fired when a user clicks the cancel button. */
     onCancelButtonClick?: () => void;
     /**
@@ -83,6 +85,7 @@ const Wizard: FunctionComponent<WizardProps> = ({
     submitButtonText = 'Submit',
     optionalText = 'optional',
     isLoadingNextStep = false,
+    isDisabledNextStep = false,
     disableStepNavigation = false,
     onNextButtonClick = () => true,
     onPreviousButtonClick = () => {},
@@ -134,6 +137,7 @@ const Wizard: FunctionComponent<WizardProps> = ({
         submitButtonText,
         optionalText,
         isLoadingNextStep,
+        isDisabledNextStep,
         disableStepNavigation,
         onNextButtonClick: handleNextButtonClick,
         onPreviousButtonClick: handlePreviousButtonClick,


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
Add a new prop to allow disabling of Next/Submit button in Wizard. This is necessary to implement client-side validation and block user from moving forward until the conditions are met. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
