### PR TITLE
Invalid comparison

### DIFF
--- a/packages/legacy/src/hooks/useScrollPosition/index.tsx
+++ b/packages/legacy/src/hooks/useScrollPosition/index.tsx
@@ -15,7 +15,7 @@
  ******************************************************************************************************************** */
 import { useRef } from 'react';
 
-const isBrowser = typeof window != undefined;
+const isBrowser = typeof window !== 'undefined';
 
 export interface ScrollPosition {
     x: number;


### PR DESCRIPTION
Hey there :) While analyzing the project I found this small issue.

The typeof is compared to undefined. This comparison is invalid because typeof always returns strings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
