### PR TITLE
fix(CognitoAuth-useSigv4Client): BREAKING CHANGE - Update the useSigv4Client to be a callback

### DIFF
--- a/packages/ui/src/components/CognitoAuth/CognitoAuth.stories.mdx
+++ b/packages/ui/src/components/CognitoAuth/CognitoAuth.stories.mdx
@@ -14,13 +14,14 @@ The following authentication flows are not supported in the current version of C
 * [Cognito hosted UI](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-app-integration.html)
 
 ## useSigv4Client
-
 A React hook returning an instance of Sigv4Client to be used to run fetch call with AWS signed API requests.
 Refer to [Docs](https://aws.github.io/aws-northstar/?path=/docs/components-cognitoauth-sigv4client-docs--page) for more details.
 
 ## Usage
 
 ```jsx
+import CognitoAuth from '@aws-northstar/ui/components/CognitoAuth';
+
 export const MyComponent = (args: CognitoAuthProps) => {
     return (
         <CognitoAuth {...args}>

--- a/packages/ui/src/components/CognitoAuth/context.ts
+++ b/packages/ui/src/components/CognitoAuth/context.ts
@@ -14,7 +14,13 @@
   limitations under the License.                                                                              *
  ******************************************************************************************************************** */
 import { createContext, useContext } from 'react';
-import { CognitoUserPool, CognitoUser } from 'amazon-cognito-identity-js';
+import {
+    CognitoUserPool,
+    CognitoUser,
+    CognitoUserSession,
+    CognitoUserAttribute,
+    GetSessionOptions,
+} from 'amazon-cognito-identity-js';
 
 export interface CognitoAuthContextAPI {
     /**
@@ -38,11 +44,19 @@ export interface CognitoAuthContextAPI {
      */
     onSignOut: () => void;
     /**
-     * Returns an instance of current authenticated CognitoUser.
+     * Returns current authenticated CognitoUser.
      * The returned cognitoUser object does not include session.
-     * Use <cognitoUser>.getSession callback to retrieve session tokens.
+     * Use getAuthenticatedUserSession to retrieve session tokens.
      */
-    getAuthenticatedUser?: () => CognitoUser | null;
+    getAuthenticatedUser: () => CognitoUser | null;
+    /**
+     * Returns current authenticated CognitoUser user session.
+     */
+    getAuthenticatedUserSession: (options?: GetSessionOptions) => Promise<CognitoUserSession | undefined>;
+    /**
+     * Returns urrent authenticated CongitoUser user attributes.
+     */
+    getAuthenticatedUserAttributes: () => Promise<CognitoUserAttribute[] | undefined>;
 }
 
 const initialState = {
@@ -50,6 +64,8 @@ const initialState = {
     userPool: null,
     onSignOut: () => {},
     getAuthenticatedUser: () => null,
+    getAuthenticatedUserSession: () => Promise.resolve(undefined),
+    getAuthenticatedUserAttributes: () => Promise.resolve(undefined),
 };
 
 export const CognitoAuthContext = createContext<CognitoAuthContextAPI>(initialState);

--- a/packages/ui/src/components/CognitoAuth/devStories/useSigv4Client.stories.tsx
+++ b/packages/ui/src/components/CognitoAuth/devStories/useSigv4Client.stories.tsx
@@ -35,16 +35,14 @@ const AuthenticatedContent = () => {
     const { onSignOut } = useCognitoAuthContext();
     const [value, setValue] = useState('');
     const [response, setResponse] = useState();
-    const [responseError, setResponseError] = useState<Error>();
-    const { client, error } = useSigv4Client();
+    const [error, setError] = useState<Error>();
+    const client = useSigv4Client();
     const handleFetch = useCallback(async () => {
-        if (client.current) {
-            try {
-                const response = await client.current(value);
-                setResponse(await response.json());
-            } catch (err) {
-                setResponseError(err);
-            }
+        try {
+            const response = await client(value);
+            setResponse(await response.json());
+        } catch (err) {
+            setError(err);
         }
     }, [client, value]);
 
@@ -68,11 +66,6 @@ const AuthenticatedContent = () => {
                 {error && (
                     <Alert type="error" header="Error">
                         {error.message}
-                    </Alert>
-                )}
-                {responseError && (
-                    <Alert type="error" header="Error">
-                        {responseError.message}
                     </Alert>
                 )}
                 {response && (

--- a/packages/ui/src/components/CognitoAuth/hooks/useSigv4Client/index.test.tsx
+++ b/packages/ui/src/components/CognitoAuth/hooks/useSigv4Client/index.test.tsx
@@ -15,13 +15,16 @@
  ******************************************************************************************************************** */
 import useSigv4Client from '.';
 import { renderHook } from '@testing-library/react-hooks';
-import delay from '../../../../utils/delay';
 
 const mockGetAuthenticatedUser = jest.fn();
 const mockFetcher = jest.fn();
 const testRegion = 'ap-southeast-2';
 const testIdentityPoolId = 'testIdentityPoolId';
 const testUserPoolId = 'testUserPoolId';
+const testUrl = 'http://test.com';
+const testOption = {
+    method: 'POST',
+};
 
 jest.mock('../../context', () => ({
     useCognitoAuthContext: jest.fn().mockImplementation(() => {
@@ -49,20 +52,17 @@ describe('useSigv4Client', () => {
 
     it('should return fetch client', async () => {
         mockGetAuthenticatedUser.mockReturnValue('testCognitoUser');
-        const { result, rerender } = renderHook(() => useSigv4Client());
+        const { result } = renderHook(() => useSigv4Client());
 
-        await delay(1000);
-        rerender();
+        await result.current(testUrl, testOption);
 
-        expect(result.current.error).toBeUndefined();
-        expect(result.current.client.current).toBe(mockFetcher);
+        expect(mockFetcher).toHaveBeenCalledWith(testUrl, testOption);
     });
 
     it('should throw error', async () => {
         mockGetAuthenticatedUser.mockReturnValue(undefined);
         const { result } = renderHook(() => useSigv4Client());
 
-        expect(result.current.error?.message).toBe('CognitoUser is empty');
-        expect(result.current.client.current).toBeUndefined();
+        await expect(result.current(testUrl, testOption)).rejects.toThrow('CognitoUser is empty');
     });
 });

--- a/packages/ui/src/components/CognitoAuth/hooks/useSigv4Client/useSigv4Client.stories.mdx
+++ b/packages/ui/src/components/CognitoAuth/hooks/useSigv4Client/useSigv4Client.stories.mdx
@@ -13,23 +13,24 @@ useSigv4Client should be used within **CognitoAuth** context.
 **identityPoolId** and **region** should be provided as props of CognitoAuth component. 
 
 ```jsx
-// Get Sigv4Client and error (if there is any) object
-const { client, error } = useSigv4Client();
-const [response, setResponse] = useState();
-const [responseError, setResponseError] = useState<Error>();
+import useSigv4Client from '@aws-northstar/ui/components/CognitoAuth/hooks/useSigv4Client';
 
-// Use the client in the fetch call.
-const handleFetch = useCallback(async () => {
-    if (client.current) {
+...
+    // Get Sigv4Client fetch callback
+    const client = useSigv4Client();
+    const [response, setResponse] = useState();
+    const [error, setError] = useState<Error>();
+    
+    const handleFetch = useCallback(async () => {
         try {
-            // The client object returned is a React.Ref object, so use the client.current to retrieve the latest fetch client. 
-            const response = await client.current(value);
+            const response = await client(<url>, <RequestInit>);
             setResponse(await response.json());
         } catch (err) {
-            setResponseError(err);
+            setError(err);
         }
-    }
-}, [client, value]);
+    }, [client, url]);
+...
+
 ```
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR is to update the useSigv4Client to be a async callback not much data needs to be kept in the state. And consumers can use *try-catch block* to handle both initialization errors or network call errors. 

This PR is also adding two utilities function into CognitoAuthContext: getAuthenticatedUserAttributes and getAuthenticatedUserSession 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
