### PR TITLE
feat(useSigv4Client): cache credentials to reduce api call latency

### DIFF
--- a/packages/ui/src/components/CognitoAuth/hooks/useSigv4Client/index.tsx
+++ b/packages/ui/src/components/CognitoAuth/hooks/useSigv4Client/index.tsx
@@ -19,7 +19,7 @@ import { useCognitoAuthContext } from '../../context';
 import getCredentials from './utils/getCredentials';
 import EmptyArgumentError from './EmptyArgumentError';
 
-const useSigv4Client = (service: string = 'execute-api') => {
+const useSigv4Client = (service: string = 'execute-api', disableCache?: boolean) => {
     const { getAuthenticatedUser, region, identityPoolId, userPoolId } = useCognitoAuthContext();
 
     return useCallback(
@@ -33,12 +33,12 @@ const useSigv4Client = (service: string = 'execute-api') => {
             const fetcher = createSignedFetcher({
                 service,
                 region: region || 'us-east-1',
-                credentials: () => getCredentials(cognitoUser, region, identityPoolId, userPoolId),
+                credentials: () => getCredentials(cognitoUser, region, identityPoolId, userPoolId, disableCache),
             });
 
             return fetcher(input, init);
         },
-        [getAuthenticatedUser, region, identityPoolId, userPoolId, service]
+        [getAuthenticatedUser, region, identityPoolId, userPoolId, service, disableCache]
     );
 };
 

--- a/packages/ui/src/components/CognitoAuth/hooks/useSigv4Client/utils/getCredentials/cache.ts
+++ b/packages/ui/src/components/CognitoAuth/hooks/useSigv4Client/utils/getCredentials/cache.ts
@@ -1,0 +1,61 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+import { AwsCredentialIdentity } from '@aws-sdk/types';
+
+// Session storage key for cached credentials
+const STORAGE_KEY = 'northstar.sigv4fetch.session';
+
+// Credential expiration grace time before considering credentials as expired
+const OFFSET_MILLIS = 30 * 1000; // 30 seconds
+
+interface CachedCredentials extends Omit<AwsCredentialIdentity, 'expiration'> {
+    readonly expiration?: number;
+}
+
+/**
+ * Returns cached credentials from session storage (if available and they have not expired)
+ */
+export const getCachedCredentials = (): AwsCredentialIdentity | undefined => {
+    const rawCachedCredentials = window.sessionStorage.getItem(STORAGE_KEY);
+    if (rawCachedCredentials) {
+        try {
+            const cachedCredentials = JSON.parse(rawCachedCredentials) as CachedCredentials;
+            const now = Date.now();
+            if (cachedCredentials.expiration && cachedCredentials.expiration > now + OFFSET_MILLIS) {
+                return {
+                    ...cachedCredentials,
+                    expiration: new Date(cachedCredentials.expiration),
+                };
+            }
+        } catch {
+            // Credentials can't be read
+        }
+    }
+    return undefined;
+};
+
+/**
+ * Write credentials to the session storage cache
+ */
+export const setCachedCredentials = (credentials: AwsCredentialIdentity) => {
+    window.sessionStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+            ...credentials,
+            expiration: credentials.expiration?.getTime(),
+        })
+    );
+};

--- a/packages/ui/src/components/CognitoAuth/hooks/useSigv4Client/utils/getCredentials/index.test.ts
+++ b/packages/ui/src/components/CognitoAuth/hooks/useSigv4Client/utils/getCredentials/index.test.ts
@@ -13,6 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.                                                                              *
  ******************************************************************************************************************** */
+import { AwsCredentialIdentity } from '@aws-sdk/types';
 import getCredentials from '.';
 import { fromCognitoIdentityPool } from '@aws-sdk/credential-provider-cognito-identity';
 
@@ -49,6 +50,7 @@ describe('getCredentials', () => {
     afterEach(() => {
         mockCredentials.mockReset();
         (fromCognitoIdentityPool as jest.Mock).mockReset();
+        window.sessionStorage.clear();
     });
 
     it('should return credential', async () => {
@@ -65,6 +67,72 @@ describe('getCredentials', () => {
                 'cognito-idp.ap-southeast-2.amazonaws.com/testUserPoolId': 'JWT Token',
             },
         });
+    });
+
+    it('should return cached credentials', async () => {
+        const mockCreds: AwsCredentialIdentity = {
+            accessKeyId: 'access',
+            secretAccessKey: 'secret',
+            sessionToken: 'session',
+            expiration: new Date(Date.now() + 60 * 1000), // Expires after the test ends!
+        };
+
+        mockCredentials.mockResolvedValue(mockCreds);
+
+        // Get credentials twice
+        expect(await getCredentials(testCognitoUser, testRegion, testIdentityPoolId, testUserPoolId)).toEqual(
+            mockCreds
+        );
+        expect(await getCredentials(testCognitoUser, testRegion, testIdentityPoolId, testUserPoolId)).toEqual(
+            mockCreds
+        );
+
+        // Only called once, as the credentials were returned from the cache
+        expect(mockCredentials).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refresh expired credentials', async () => {
+        const mockCreds: AwsCredentialIdentity = {
+            accessKeyId: 'access',
+            secretAccessKey: 'secret',
+            sessionToken: 'session',
+            expiration: new Date(Date.now() - 60 * 1000), // Already expired
+        };
+
+        mockCredentials.mockResolvedValue(mockCreds);
+
+        // Get credentials twice
+        expect(await getCredentials(testCognitoUser, testRegion, testIdentityPoolId, testUserPoolId)).toEqual(
+            mockCreds
+        );
+        expect(await getCredentials(testCognitoUser, testRegion, testIdentityPoolId, testUserPoolId)).toEqual(
+            mockCreds
+        );
+
+        // Called twice, as the cached credentials have expired
+        expect(mockCredentials).toHaveBeenCalledTimes(2);
+    });
+
+    it('should refetch credentials when cache is disabled', async () => {
+        const mockCreds: AwsCredentialIdentity = {
+            accessKeyId: 'access',
+            secretAccessKey: 'secret',
+            sessionToken: 'session',
+            expiration: new Date(Date.now() + 60 * 1000), // Expires after the test ends!
+        };
+
+        mockCredentials.mockResolvedValue(mockCreds);
+
+        // Get credentials twice, with caching disabled
+        expect(await getCredentials(testCognitoUser, testRegion, testIdentityPoolId, testUserPoolId, true)).toEqual(
+            mockCreds
+        );
+        expect(await getCredentials(testCognitoUser, testRegion, testIdentityPoolId, testUserPoolId, true)).toEqual(
+            mockCreds
+        );
+
+        // Called twice, as caching is disabled
+        expect(mockCredentials).toHaveBeenCalledTimes(2);
     });
 
     it('should throw error if region is empty', async () => {


### PR DESCRIPTION
*Description of changes:*

Previously prior to every api call, a request to cognito was sent to fetch credentials.

This change caches credentials until 30s before they expire, removing the extra calls and reducing api call latency.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
