### PR TITLE
feat(InfiniteQuerySelect): add infinite query select component

### DIFF
--- a/packages/ui/src/components/InfiniteQuerySelect/index.stories.tsx
+++ b/packages/ui/src/components/InfiniteQuerySelect/index.stories.tsx
@@ -1,0 +1,119 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+import { ComponentStory, Meta } from '@storybook/react';
+import InfiniteQuerySelect, { InfiniteQuerySelectProps } from '.';
+import { QueryClient, QueryClientProvider, useInfiniteQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import { SelectProps } from '@cloudscape-design/components/select';
+
+interface TestDataItem {
+    readonly id: string;
+    readonly name: string;
+    readonly value: number;
+}
+
+interface TestDataResponse {
+    readonly items: TestDataItem[];
+    readonly nextPageStart?: number;
+}
+
+type OmittedProps = 'query' | 'itemsKey' | 'toOption' | 'selectedOption' | 'onChange';
+
+export default {
+    component: InfiniteQuerySelect,
+    title: 'Components/InfiniteQuerySelect',
+    decorators: [
+        (Story) => (
+            <QueryClientProvider client={new QueryClient()}>
+                <Story />
+            </QueryClientProvider>
+        ),
+    ],
+} as Meta<Omit<InfiniteQuerySelectProps<TestDataItem, 'items', TestDataItem, unknown>, OmittedProps>>;
+
+const useTestData = (maxPages?: number) =>
+    useInfiniteQuery(
+        ['querykey'],
+        ({ pageParam }) => {
+            return new Promise<TestDataResponse>((resolve) => {
+                const page = pageParam ?? 0;
+                setTimeout(
+                    () =>
+                        resolve({
+                            items: [
+                                { id: `item_${page + 1}`, name: `Item ${page + 1}`, value: page + 1 },
+                                { id: `item_${page + 2}`, name: `Item ${page + 2}`, value: page + 2 },
+                                { id: `item_${page + 3}`, name: `Item ${page + 3}`, value: page + 3 },
+                            ],
+                            nextPageStart: maxPages && page >= maxPages ? undefined : page + 3,
+                        }),
+                    500
+                );
+            });
+        },
+        {
+            getNextPageParam: (res) => res.nextPageStart,
+        }
+    );
+
+const toOption = (item: TestDataItem): SelectProps.Option => ({
+    label: item.name,
+    value: item.id,
+});
+
+const Template: ComponentStory<typeof InfiniteQuerySelect<TestDataItem, 'items', TestDataItem, unknown>> = (
+    args: Omit<InfiniteQuerySelectProps<TestDataItem, 'items', TestDataItem, unknown>, OmittedProps>
+) => {
+    const query = useTestData(10);
+    const [selectedOption, setSelectedOption] = useState<SelectProps.Option | null>(null);
+    return (
+        <InfiniteQuerySelect
+            query={query}
+            itemsKey={'items'}
+            toOption={toOption}
+            {...args}
+            selectedOption={selectedOption}
+            onChange={(e) => setSelectedOption(e.detail.selectedOption)}
+        />
+    );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+    placeholder: 'Select an item...',
+};
+
+Default.parameters = {
+    docs: {
+        source: {
+            // Since we use decorators and hooks in the story template, storybook doesn't render the code correctly.
+            // Override the code instead.
+            code: `// Generated hook from Type Safe API, or your custom tanstack react-query "useInfiniteQuery" hook
+const items = useListItems();
+
+return (
+    <InfiniteQuerySelect
+        // Pass in your query hook
+        query={items}
+        // Pass in the key in infinite query page response containing the list of items
+        itemsKey="items"
+        // Pass a function to convert an item to a select option
+        toOption={(item) => ({ label: item.name, value: item.id })}
+    />
+);`,
+        },
+    },
+};

--- a/packages/ui/src/components/InfiniteQuerySelect/index.test.tsx
+++ b/packages/ui/src/components/InfiniteQuerySelect/index.test.tsx
@@ -1,0 +1,53 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+import wrapper from '@cloudscape-design/components/test-utils/dom';
+import { cleanup, waitFor, render, act } from '@testing-library/react';
+import * as stories from './index.stories';
+import { composeStories } from '@storybook/react';
+import userEvent from '@testing-library/user-event';
+
+const { Default } = composeStories(stories);
+
+describe('InfiniteQuerySelect', () => {
+    afterEach(() => {
+        jest.resetAllMocks();
+        cleanup();
+    });
+
+    it('should fetch pages of options', async () => {
+        const { container } = render(<Default />);
+        const select = wrapper(container).findSelect();
+
+        // Click on the select box
+        await act(() => {
+            userEvent.click(select!.findDropdown().find('button')!.getElement());
+        });
+
+        const dropdown = select?.findDropdown();
+
+        // It should load the first 3 items
+        await waitFor(() => expect(dropdown?.findOptions() ?? []).toHaveLength(3));
+        expect(dropdown?.findOption(1)!.findLabel().getElement()).toHaveTextContent('Item 1');
+        expect(dropdown?.findOption(2)!.findLabel().getElement()).toHaveTextContent('Item 2');
+        expect(dropdown?.findOption(3)!.findLabel().getElement()).toHaveTextContent('Item 3');
+
+        // Then fetch another page of 3 more items shortly afterwards
+        await waitFor(() => expect(dropdown?.findOptions() ?? []).toHaveLength(6));
+        expect(dropdown?.findOption(4)!.findLabel().getElement()).toHaveTextContent('Item 4');
+        expect(dropdown?.findOption(5)!.findLabel().getElement()).toHaveTextContent('Item 5');
+        expect(dropdown?.findOption(6)!.findLabel().getElement()).toHaveTextContent('Item 6');
+    });
+});

--- a/packages/ui/src/components/InfiniteQuerySelect/index.tsx
+++ b/packages/ui/src/components/InfiniteQuerySelect/index.tsx
@@ -1,0 +1,88 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.                                                                              *
+ ******************************************************************************************************************** */
+import Select, { SelectProps } from '@cloudscape-design/components/select';
+import type { UseInfiniteQueryResult } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
+
+/**
+ * Options for the infinite query select
+ */
+export interface InfiniteQuerySelectProps<TItem, K extends string, TExtendedItem extends TItem, TError>
+    extends Omit<SelectProps, 'options' | 'onLoadItems' | 'statusType'> {
+    /**
+     * Tanstack query hook result used to fetch items
+     */
+    readonly query: UseInfiniteQueryResult<Record<K, TItem[]>, TError>;
+    /**
+     * Key in the response under which the items to select are returned
+     */
+    readonly itemsKey: K;
+    /**
+     * Method to convert an individual item to an option definition (the entity used by the select component).
+     * It's recommended to return a `value` which uniquely identifies the item
+     */
+    readonly toOption: (item: TItem) => SelectProps.Option;
+    /**
+     * Optional function to compute additional fields or add items, called with all pages of data whenever new data is loaded
+     */
+    readonly extendData?: (item: TItem[]) => TExtendedItem[];
+}
+
+/**
+ * Extends the Cloudscape Select component with pagination options for @tanstack/react-query infinite query hooks.
+ * Compatible with generated hooks for paginated operations from <a href='https://aws.github.io/aws-pdk/developer_guides/type-safe-api/index.html' target='_blank' rel='noreferrer noopener'>AWS PDK Type Safe API</a>.
+ */
+const InfiniteQuerySelect = <TItem, K extends string, TExtendedItem extends TItem, TError>({
+    query,
+    itemsKey,
+    toOption,
+    extendData,
+    ...props
+}: InfiniteQuerySelectProps<TItem, K, TExtendedItem, TError>) => {
+    const allLocalData = useMemo(() => {
+        const flattenedData = (query?.data?.pages ?? []).flatMap((p) => p[itemsKey]);
+        return extendData ? extendData(flattenedData) : flattenedData;
+    }, [query.data?.pages, extendData, itemsKey]);
+
+    const options = useMemo<SelectProps.Option[]>(() => {
+        return allLocalData.map(toOption);
+    }, [allLocalData, toOption]);
+
+    const onLoadItems = useCallback<NonNullable<SelectProps['onLoadItems']>>(
+        async ({ detail: { firstPage, samePage } }) => {
+            if (firstPage) {
+                await query.refetch();
+            }
+            if (!samePage) {
+                await query.fetchNextPage();
+            }
+        },
+        [query]
+    );
+
+    const status = useMemo<SelectProps['statusType']>(() => {
+        if (query.isLoading || query.isFetchingNextPage) {
+            return 'loading';
+        } else if (query.hasNextPage) {
+            return 'pending';
+        }
+        return 'finished';
+    }, [query.isLoading, query.hasNextPage, query.isFetchingNextPage]);
+
+    return <Select options={options} onLoadItems={onLoadItems} statusType={status} {...props} />;
+};
+
+export default InfiniteQuerySelect;

--- a/packages/ui/src/components/InfiniteQueryTable/index.stories.tsx
+++ b/packages/ui/src/components/InfiniteQueryTable/index.stories.tsx
@@ -99,6 +99,35 @@ const Template: ComponentStory<typeof InfiniteQueryTable<TestDataItem, 'items', 
 
 export const Default = Template.bind({});
 Default.args = {};
+Default.parameters = {
+    docs: {
+        source: {
+            code: `// Generated hook from Type Safe API, or your custom tanstack react-query "useInfiniteQuery" hook
+const items = useListItems();
+
+return (
+    <InfiniteQueryTable
+        // Pass in your query hook
+        query={items}
+        // Pass in the key in infinite query page response containing the list of items
+        itemsKey="items"
+        columnDefinitions={[
+            {
+                id: 'name',
+                header: 'Name',
+                cell: (item) => item.name,
+            },
+            {
+                id: 'type',
+                header: 'Type',
+                cell: (item) => item.type,
+            },
+        ]}
+    />
+);`,
+        },
+    },
+};
 
 export const ClientSideTextFilter = Template.bind({});
 ClientSideTextFilter.args = {
@@ -107,12 +136,81 @@ ClientSideTextFilter.args = {
         placeholder: 'Find items...',
     },
 };
+ClientSideTextFilter.parameters = {
+    docs: {
+        source: {
+            code: `// Generated hook from Type Safe API, or your custom tanstack react-query "useInfiniteQuery" hook
+const items = useListItems();
+
+return (
+    <InfiniteQueryTable
+        // Pass in your query hook
+        query={items}
+        // Pass in the key in infinite query page response containing the list of items
+        itemsKey="items"
+        // Filter items which have been loaded client side
+        clientSideTextFilter={{
+            filterFunction: (filterText, item) => item.name.includes(filterText),
+            placeholder: 'Find items...',
+        }}
+        columnDefinitions={[
+            {
+                id: 'name',
+                header: 'Name',
+                cell: (item) => item.name,
+            },
+            {
+                id: 'type',
+                header: 'Type',
+                cell: (item) => item.type,
+            },
+        ]}
+    />
+);`,
+        },
+    },
+};
 
 export const ClientSideSort = Template.bind({});
 ClientSideSort.args = {
     clientSideSort: {
         defaultSortingColumn: {
             sortingField: 'name',
+        },
+    },
+};
+ClientSideSort.parameters = {
+    docs: {
+        source: {
+            code: `// Generated hook from Type Safe API, or your custom tanstack react-query "useInfiniteQuery" hook
+const items = useListItems();
+
+return (
+    <InfiniteQueryTable
+        // Pass in your query hook
+        query={items}
+        // Pass in the key in infinite query page response containing the list of items
+        itemsKey="items"
+        // Sort items which have been loaded client side
+        clientSideSort={{
+            defaultSortingColumn: {
+                sortingField: 'name',
+            },
+        }}
+        columnDefinitions={[
+            {
+                id: 'name',
+                header: 'Name',
+                cell: (item) => item.name,
+            },
+            {
+                id: 'type',
+                header: 'Type',
+                cell: (item) => item.type,
+            },
+        ]}
+    />
+);`,
         },
     },
 };

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -31,5 +31,7 @@ export { default as Table } from './Table';
 export * from './Table';
 export { default as InfiniteQueryTable } from './InfiniteQueryTable';
 export * from './InfiniteQueryTable';
+export { default as InfiniteQuerySelect } from './InfiniteQuerySelect';
+export * from './InfiniteQuerySelect';
 export { default as CognitoAuth } from './CognitoAuth';
 export * from './CognitoAuth';


### PR DESCRIPTION
Like InfiniteQueryTable, this wraps the Cloudscape Select component for selecting from items which are returned from a paginated API.

Additionally fix the code examples in the storybook documentation for InfiniteQueryTable since it did not render properly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
