### PR TITLE
fix(FormRenderer-Wizard): Fix an issue where validation can be skipped in certain scenarios. Close #991

### DIFF
--- a/packages/ui/src/components/FormRenderer/components/Wizard/index.tsx
+++ b/packages/ui/src/components/FormRenderer/components/Wizard/index.tsx
@@ -64,6 +64,7 @@ const Wizard: FC<WizardProps> = ({
     const formOptions = useFormApi();
     const { isSubmitting } = useFormRendererContext();
     const [activeStepIndex, setActiveStepIndex] = useState(props.activeStepIndex || 0);
+    const [maxStepIndex, setMaxStepIndex] = useState(0);
     const [isLoadingNextStep, setIsLoadingNextStep] = useState(props.isLoadingNextStep || isSubmitting);
     const [errorText, setErrorText] = useState<string>();
 
@@ -132,6 +133,7 @@ const Wizard: FC<WizardProps> = ({
             const response = await handleNavigating(event);
             if (response.continued) {
                 setActiveStepIndex(requestedStepIndex);
+                setMaxStepIndex((prev) => (requestedStepIndex > prev ? requestedStepIndex : prev));
             } else {
                 setErrorText(response.errorText);
             }
@@ -144,7 +146,7 @@ const Wizard: FC<WizardProps> = ({
             setErrorText(undefined);
             const requestedStepIndex = event.detail.requestedStepIndex;
 
-            if (activeStepIndex < event.detail.requestedStepIndex) {
+            if (activeStepIndex < event.detail.requestedStepIndex || activeStepIndex < maxStepIndex) {
                 const state = formOptions.getState();
                 setShowError(true);
                 if (!(state.invalid || state.validating || state.submitting)) {
@@ -154,7 +156,7 @@ const Wizard: FC<WizardProps> = ({
                 processNavigate(requestedStepIndex, event);
             }
         },
-        [activeStepIndex, formOptions, processNavigate]
+        [activeStepIndex, maxStepIndex, formOptions, processNavigate]
     );
 
     return (


### PR DESCRIPTION
*Issue #, if available:*

#991 

*Description of changes:*

This PR is to fix an issue where validation can be skipped in certain scenarios, for instance, the scenarios specified in the issue #991 by using a maximum step index parameter. If the active step index is less than the maximum step index (For the scenario that the user has visited a page after the current page and navigated back), the validation will be triggered. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
