### PR TITLE
fix(form-renderer): display errors returned by submit callback

### DIFF
--- a/packages/ui/src/components/FormRenderer/hoc/withDataDrivenFormField/index.tsx
+++ b/packages/ui/src/components/FormRenderer/hoc/withDataDrivenFormField/index.tsx
@@ -67,11 +67,11 @@ function withDataDrivenFormField(
             input,
 
             validateOnMount,
-            meta: { error, submitFailed },
+            meta: { error, submitFailed, submitError },
             showError,
         } = useFieldApiProps;
         const controlId = useUniqueId(input.name);
-        const errorText = getErrorText(validateOnMount, submitFailed, showError, error);
+        const errorText = getErrorText(validateOnMount, submitFailed, showError, error, submitError);
 
         const onFocus = input.onFocus;
         const onBlur = input.onBlur;

--- a/packages/ui/src/components/FormRenderer/utils/getErrorText/index.ts
+++ b/packages/ui/src/components/FormRenderer/utils/getErrorText/index.ts
@@ -13,8 +13,17 @@
   See the License for the specific language governing permissions and
   limitations under the License.                                                                              *
  ******************************************************************************************************************** */
-const getErrorText = (validateOnMount: any, submitFailed: boolean | undefined, showError: any, error: any) => {
-    return (validateOnMount || submitFailed || showError) && error && typeof error === 'string' ? error : undefined;
+const getErrorText = (
+    validateOnMount: any,
+    submitFailed: boolean | undefined,
+    showError: any,
+    error: any,
+    submitError: any
+) => {
+    const err = error ?? submitError;
+    const shouldShowError = validateOnMount || submitFailed || showError;
+    const hasErrorText = err && typeof err === 'string';
+    return shouldShowError && hasErrorText ? err : undefined;
 };
 
 export default getErrorText;


### PR DESCRIPTION
Errors returned by the `onSubmit` callback end up in the `submitError` property rather than `error`. Update the `getErrorText` method to display either if defined.

Fixes #1063 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
